### PR TITLE
[KBV-262] Github workflows deploy to dev and build

### DIFF
--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -1,0 +1,66 @@
+name: Deploy to dev
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: # deploy manually
+
+jobs:
+  deploy:
+    name: Deploy to dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      AWS_REGION: eu-west-2
+      STACK_NAME: di-ipv-cri-fraud-api-dev
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: zulu
+
+      - name: Setup SAM
+        uses: aws-actions/setup-sam@v1
+
+      - name: Assume temporary AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: SAM Validate
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
+
+      - name: Generate code signing config
+        id: signing
+        uses: rusty-actions/sam-code-signing-config@39f63740a9f8622eb9b6755413a31a6013a62a86
+        with:
+          template: ./deploy/template.yaml
+          profile: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
+
+      - name: Gradle build
+        run: ./gradlew build
+
+      - name: SAM build
+        run: sam build -t deploy/template.yaml
+
+      - name: SAM package
+        run: |
+          sam package -t deploy/template.yaml  \
+            ${{ steps.signing.outputs.signing_config }} \
+            --s3-bucket ${{ secrets.DEV_ARTIFACT_SOURCE_BUCKET_NAME }} \
+            --region ${{ env.AWS_REGION }} --output-template-file=cf-template.yaml
+
+      - name: Zip the CloudFormation template
+        run: zip template.zip cf-template.yaml
+
+      - name: Upload zipped CloudFormation artifact to S3
+        env:
+          DEV_ARTIFACT_SOURCE_BUCKET_NAME: ${{ secrets.DEV_ARTIFACT_SOURCE_BUCKET_NAME }}
+        run: aws s3 cp template.zip "s3://$DEV_ARTIFACT_SOURCE_BUCKET_NAME/template.zip"

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -1,0 +1,79 @@
+name: Package for Build
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Package for build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      AWS_REGION: eu-west-2
+      ENVIRONMENT: build
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+        
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: zulu
+
+      - name: Setup SAM
+        uses: aws-actions/setup-sam@v1
+
+      - name: Assume temporary AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Gradle build
+        run: ./gradlew clean build
+
+      - name: Generate code signing config
+        id: signing
+        uses: rusty-actions/sam-code-signing-config@39f63740a9f8622eb9b6755413a31a6013a62a86
+        with:
+          template: ./deploy/template.yaml
+          profile: ${{ secrets.SIGNING_PROFILE_NAME }}
+
+      - name: SAM Validate
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
+      
+      - name: SAM build
+        run: sam build -t deploy/template.yaml
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push testing image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG acceptance-tests
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+      - name: SAM package
+        run: |
+          sam package -t deploy/template.yaml  \
+            ${{ steps.signing.outputs.signing_config }} \
+            --s3-bucket ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }} \
+            --region ${{ env.AWS_REGION }} --output-template-file=cf-template.yaml
+
+      - name: Zip the CloudFormation template
+        run: zip template.zip cf-template.yaml
+
+      - name: Upload zipped CloudFormation artifact to S3
+        env:
+          ARTIFACT_SOURCE_BUCKET_NAME: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
+        run: aws s3 cp template.zip "s3://$ARTIFACT_SOURCE_BUCKET_NAME/template.zip"
+

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -1,0 +1,126 @@
+name: Pre-merge checks
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+
+jobs:
+  style-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: zulu
+          cache: 'gradle'
+      - name: Run Spotless
+        run: ./gradlew --no-daemon spotlessCheck
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: zulu
+          cache: 'gradle'
+      - name: Build Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            .gradle/
+            */build/
+            !*/build/reports
+            !*/build/jacoco
+          key: ${{ runner.os }}-build-${{ github.sha }}
+      - name: Run Build
+        run: ./gradlew --parallel build -x test -x spotlessApply -x spotlessCheck
+
+  run-unit-tests:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: zulu
+          cache: 'gradle'
+      - name: Build Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            .gradle/
+            */build/
+            !*/build/reports
+            !*/build/jacoco
+          key: ${{ runner.os }}-build-${{ github.sha }}
+      - name: Run Unit Tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew --parallel test jacocoTestReport -x spotlessApply -x spotlessCheck
+      - name: Upload Unit Test Reports
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: unit-test-reports
+          path: |
+            */build/reports/
+          retention-days: 5
+      - name: Cache Unit Test Reports
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
+          path: |
+            */build/jacoco/
+            */build/reports/
+
+  run-sonar-analysis:
+    runs-on: ubuntu-latest
+    needs:
+      - run-unit-tests
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: zulu
+          cache: 'gradle'
+      - name: Build Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            .gradle/
+            */build/
+            !*/build/reports
+            !*/build/jacoco
+          key: ${{ runner.os }}-build-${{ github.sha }}
+      - name: Cache Unit Test Reports
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
+          path: |
+            */build/jacoco/
+            */build/reports/
+      - name: Run SonarCloud Analysis
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonarqube -x test -x spotlessApply -x spotlessCheck

--- a/README.md
+++ b/README.md
@@ -11,3 +11,28 @@ Build with `./gradlew clean build buildZip`
 Build a sam config toml file once only by running:
 `sam deploy -t deploy/template.yaml --guided`
 Then run `gds aws <account> -- ./deploy.sh`
+
+## Deploy to AWS lambda
+
+Automated GitHub actions deployments to di-ipv-cri-build have been enabled for this repository.
+Manual GitHub actions deployments to di-ipv-cri-dev can be triggered from the GitHub actions menu.
+
+The automated deployments are triggered on a push to main after PR approval.
+
+GitHub secrets are required for deployment.
+
+Required GitHub secrets:
+
+| Secret | Description |
+| ------ | ----------- |
+| ARTIFACT_SOURCE_BUCKET_NAME | Upload artifact bucket |
+| GH_ACTIONS_ROLE_ARN | Assumed role IAM ARN |
+| SIGNING_PROFILE_NAME | Signing profile name |
+
+For Dev the following equivalent GitHub secrets:
+
+| Secret                          | Description |
+|---------------------------------| ----------- |
+| DEV_ARTIFACT_SOURCE_BUCKET_NAME | Upload artifact bucket |
+| DEV_GH_ACTIONS_ROLE_ARN         | Assumed role IAM ARN |
+| DEV_SIGNING_PROFILE_NAME        | Signing profile name |


### PR DESCRIPTION
## Proposed changes

### What changed

Github workflows added to deploy the fraud api to dev and build with promotion to staging

### Why did it change

To integrate the platform teams deployment process into dev and build to enable easier and consistent flows through the environments

### Issue tracking

- [KBV-261](https://govukverify.atlassian.net/browse/KBV-261)
- [KBV-262](https://govukverify.atlassian.net/browse/KBV-262)

## Checklists

### Environment variables or secrets

- [X] Documented in the [README](./blob/main/README.md)

### Other considerations

The template will need to be updated to reference the exported security group.