### PR TITLE
KBV-499 Receive and validate Experian response.

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/DecisionElement.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/DecisionElement.java
@@ -36,7 +36,7 @@ public class DecisionElement {
     private List<Rule> rules = new ArrayList<>();
 
     @JsonProperty("warningsErrors")
-    private List<Object> warningsErrors = new ArrayList<>();
+    private List<WarningsErrors> warningsErrors = new ArrayList<>();
 
     @JsonProperty("otherData")
     private OtherData otherData;
@@ -114,11 +114,11 @@ public class DecisionElement {
         this.rules = rules;
     }
 
-    public List<Object> getWarningsErrors() {
+    public List<WarningsErrors> getWarningsErrors() {
         return warningsErrors;
     }
 
-    public void setWarningsErrors(List<Object> warningsErrors) {
+    public void setWarningsErrors(List<WarningsErrors> warningsErrors) {
         this.warningsErrors = warningsErrors;
     }
 

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/OrchestrationDecision.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/OrchestrationDecision.java
@@ -30,6 +30,9 @@ public class OrchestrationDecision {
     @JsonProperty("nextAction")
     private String nextAction;
 
+    @JsonProperty("appReference")
+    private String appReference;
+
     @JsonProperty("decisionTime")
     private String decisionTime;
 
@@ -87,6 +90,14 @@ public class OrchestrationDecision {
 
     public void setNextAction(String nextAction) {
         this.nextAction = nextAction;
+    }
+
+    public void setAppReference(String appReference) {
+        this.appReference = appReference;
+    }
+
+    public String getAppReference() {
+        return appReference;
     }
 
     public String getDecisionTime() {

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/OverallResponse.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/OverallResponse.java
@@ -15,14 +15,17 @@ public class OverallResponse {
     @JsonProperty("decisionText")
     private String decisionText;
 
+    @JsonProperty("score")
+    private int score;
+
     @JsonProperty("decisionReasons")
     private List<String> decisionReasons = new ArrayList<>();
 
     @JsonProperty("recommendedNextActions")
-    private List<Object> recommendedNextActions = new ArrayList<>();
+    private List<String> recommendedNextActions = new ArrayList<>();
 
     @JsonProperty("spareObjects")
-    private List<Object> spareObjects = new ArrayList<>();
+    private List<String> spareObjects = new ArrayList<>();
 
     public String getDecision() {
         return decision;
@@ -34,6 +37,14 @@ public class OverallResponse {
 
     public String getDecisionText() {
         return decisionText;
+    }
+
+    public void setScore(int score) {
+        this.score = score;
+    }
+
+    public int getScore() {
+        return score;
     }
 
     public void setDecisionText(String decisionText) {
@@ -48,19 +59,19 @@ public class OverallResponse {
         this.decisionReasons = decisionReasons;
     }
 
-    public List<Object> getRecommendedNextActions() {
+    public List<String> getRecommendedNextActions() {
         return recommendedNextActions;
     }
 
-    public void setRecommendedNextActions(List<Object> recommendedNextActions) {
+    public void setRecommendedNextActions(List<String> recommendedNextActions) {
         this.recommendedNextActions = recommendedNextActions;
     }
 
-    public List<Object> getSpareObjects() {
+    public List<String> getSpareObjects() {
         return spareObjects;
     }
 
-    public void setSpareObjects(List<Object> spareObjects) {
+    public void setSpareObjects(List<String> spareObjects) {
         this.spareObjects = spareObjects;
     }
 }

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/WarningsErrors.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/WarningsErrors.java
@@ -1,0 +1,38 @@
+package uk.gov.di.ipv.cri.fraud.api.gateway.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class WarningsErrors {
+    @JsonProperty("responseCode")
+    private String responseCode;
+
+    @JsonProperty("responseType")
+    private ResponseType responseType;
+
+    @JsonProperty("responseMessage")
+    private String responseMessage;
+
+    public void setResponseCode(String responseCode) {
+        this.responseCode = responseCode;
+    }
+
+    public String getResponseCode() {
+        return responseCode;
+    }
+
+    public void setResponseType(ResponseType responseType) {
+        this.responseType = responseType;
+    }
+
+    public ResponseType getResponseType() {
+        return responseType;
+    }
+
+    public void setResponseMessage(String responseMessage) {
+        this.responseMessage = responseMessage;
+    }
+
+    public String getResponseMessage() {
+        return responseMessage;
+    }
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidator.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidator.java
@@ -1,0 +1,413 @@
+package uk.gov.di.ipv.cri.fraud.api.service;
+
+import uk.gov.di.ipv.cri.fraud.api.domain.ValidationResult;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.*;
+import uk.gov.di.ipv.cri.fraud.api.util.JsonValidationUtility;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IdentityVerificationInfoResponseValidator {
+    public static final int HEADER_TENANT_ID_MAX_LEN = 30;
+    public static final int HEADER_REQUEST_TYPE_MAX_LEN = 40;
+    public static final int HEADER_CLIENT_REF_ID_MAX_LEN = 90;
+    public static final int HEADER_EXP_REQUEST_ID_MAX_LEN = 90;
+    public static final int OVERALL_RESPONSE_DECISION_MAX_LEN = 10;
+    public static final int OVERALL_RESPONSE_DECISION_SCORE_MIN_VALUE = 0;
+    public static final int OVERALL_RESPONSE_DECISION_SCORE_MAX_VALUE = 99999;
+    public static final int OVERALL_RESPONSE_DECISION_TEXT_MAX_LEN = 30;
+    public static final int OVERALL_RESPONSE_DECISION_REASONS_MAX_REASON_LEN = 90;
+    public static final int OVERALL_RESPONSE_RECOMMENDED_NEXT_ACTIONS_NEXT_ACTION_MAX_LEN = 200;
+    public static final int OVERALL_RESPONSE_RECOMMENDED_SPARE_OBJECTS_SPARE_OBJECT_MAX_LEN = 200;
+    public static final int HEADER_RESPONSE_CODE_MAX_LEN = 20;
+    public static final int HEADER_RESPONSE_MESSAGE_MAX_LEN = 300;
+    public static final int ORCHESTRATION_DECISION_SEQUENCE_ID_MAX_LEN = 40;
+    public static final int ORCHESTRATION_DECISION_SOURCE_MAX_LEN = 20;
+    public static final int ORCHESTRATION_DECISION_DECISION_MAX_LEN = 10;
+    public static final int ORCHESTRATION_DECISION_DECISION_REASONS_REASON_MAX_LEN = 90;
+    public static final int ORCHESTRATION_DECISION_SCORE_MIN_VALUE = 0;
+    public static final int ORCHESTRATION_DECISION_SCORE_MAX_VALUE = 99999;
+    public static final int ORCHESTRATION_DECISION_DECISION_TEXT_MAX_LEN = 30;
+    public static final int ORCHESTRATION_DECISION_NEXT_ACTION_MAX_LEN = 20;
+    public static final int ORCHESTRATION_DECISION_APP_REFERENCE_MAX_LEN = 20;
+    public static final int DECISION_ELEMENTS_APP_ID_MAX_LEN = 40;
+    public static final int DECISION_ELEMENTS_SERVICE_NAME_MAX_LEN = 40;
+    public static final int DECISION_ELEMENTS_DECISION_MAX_LEN = 20;
+    public static final int DECISION_ELEMENTS_SCORE_MIN_VALUE = 0;
+    public static final int DECISION_ELEMENTS_SCORE_MAX_VALUE = 90;
+    public static final int DECISION_ELEMENTS_DECISION_TEXT_MAX_LEN = 20;
+    public static final int DECISION_ELEMENTS_DECISION_REASON_MAX_LEN = 100;
+    public static final int DECISION_ELEMENTS_APP_REF_MAX_LEN = 100;
+    public static final int DECISION_ELEMENTS_RULE_NAME_SERVICE_LEVEL_SCORE_MIN = 0;
+    public static final int DECISION_ELEMENTS_RULE_NAME_SERVICE_LEVEL_SCORE_MAX = 90;
+    public static final int DECISION_ELEMENTS_WARNING_RESPONSE_CODE_MAX_LEN = 40;
+    public static final int DECISION_ELEMENTS_WARNING_RESPONSE_MESSAGE_MAX_LEN = 300;
+
+    public static final String DECISION_FIELD_NAME = "Decision";
+    public static final String SCORE_FIELD_NAME = "Score";
+    public static final String DECISION_TEXT_FIELD_NAME = "DecisionText";
+
+    public static final String NULL_RESPONSE_ERROR_MESSAGE = "Response is null";
+    public static final String NULL_HEADER_ERROR_MESSAGE = "Header not found.";
+    public static final String NULL_HEADER_OVERALL_RESPONSE_ERROR_MESSAGE =
+            "Header Overall response not found.";
+    public static final String RESPONSE_TYPE_ERROR_MESSAGE =
+            "Header Response Type INFO not found - ";
+    public static final String NULL_CLIENT_RESPONSE_PAYLOAD_ERROR_MESSAGE =
+            "ClientResponsePayload not found.";
+    public static final String WARNINGS_ERRORS_FALL_BACK_ERROR_MESAGE =
+            "DecisionElement:ResponseType:Error listed in WarningsErrors (Cannot log as values also had validation errors).";
+
+    public ValidationResult<List<String>> validate(IdentityVerificationResponse response) {
+
+        final List<String> validationErrors = new ArrayList<>();
+
+        if (response != null) {
+            validateIdentityVerificationResponseHeader(
+                    response.getResponseHeader(), validationErrors);
+
+            validateIdentityVerificationResponseClientResponsePayload(
+                    response.getClientResponsePayload(), validationErrors);
+        } else {
+            validationErrors.add(NULL_RESPONSE_ERROR_MESSAGE);
+        }
+
+        return new ValidationResult<>(validationErrors.isEmpty(), validationErrors);
+    }
+
+    private void validateIdentityVerificationResponseHeader(
+            ResponseHeader header, final List<String> validationErrors) {
+        if (header == null) {
+            validationErrors.add(NULL_HEADER_ERROR_MESSAGE);
+            return;
+        }
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                header.getTenantID(), HEADER_TENANT_ID_MAX_LEN, "TenantID", validationErrors);
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                header.getRequestType(),
+                HEADER_REQUEST_TYPE_MAX_LEN,
+                "RequestType",
+                validationErrors);
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                header.getClientReferenceId(),
+                HEADER_CLIENT_REF_ID_MAX_LEN,
+                "ClientReferenceId",
+                validationErrors);
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                header.getExpRequestId(),
+                HEADER_EXP_REQUEST_ID_MAX_LEN,
+                "ExpRequestId",
+                validationErrors);
+
+        JsonValidationUtility.validateTimeStampData(
+                header.getMessageTime(), "MessageTime", validationErrors);
+
+        validateIdentityVerificationResponseHeaderOverallResponse(
+                header.getOverallResponse(), validationErrors);
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                header.getResponseCode(),
+                HEADER_RESPONSE_CODE_MAX_LEN,
+                "ResponseCode",
+                validationErrors);
+
+        // Validation is based on the assumption that we are validating an info response.
+        if (header.getResponseType() != ResponseType.INFO) {
+            validationErrors.add(RESPONSE_TYPE_ERROR_MESSAGE + header.getResponseType());
+        }
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                header.getResponseMessage(),
+                HEADER_RESPONSE_MESSAGE_MAX_LEN,
+                "ResponseMessage",
+                validationErrors);
+    }
+
+    private void validateIdentityVerificationResponseHeaderOverallResponse(
+            OverallResponse overallResponse, final List<String> validationErrors) {
+        if (overallResponse != null) {
+            String subObjectName = "OverallResponse:";
+
+            JsonValidationUtility.validateStringDataEmptyIsFail(
+                    overallResponse.getDecision(),
+                    OVERALL_RESPONSE_DECISION_MAX_LEN,
+                    subObjectName + DECISION_FIELD_NAME,
+                    validationErrors);
+
+            JsonValidationUtility.validateIntegerRangeData(
+                    overallResponse.getScore(),
+                    OVERALL_RESPONSE_DECISION_SCORE_MIN_VALUE,
+                    OVERALL_RESPONSE_DECISION_SCORE_MAX_VALUE,
+                    subObjectName + SCORE_FIELD_NAME,
+                    validationErrors);
+
+            JsonValidationUtility.validateStringDataEmptyIsFail(
+                    overallResponse.getDecisionText(),
+                    OVERALL_RESPONSE_DECISION_TEXT_MAX_LEN,
+                    subObjectName + DECISION_TEXT_FIELD_NAME,
+                    validationErrors);
+
+            if (JsonValidationUtility.validateListDataEmptyIsFail(
+                    overallResponse.getDecisionReasons(),
+                    subObjectName + "DecisionReasons",
+                    validationErrors)) {
+                for (String reason : overallResponse.getDecisionReasons()) {
+                    JsonValidationUtility.validateStringDataEmptyIsFail(
+                            reason,
+                            OVERALL_RESPONSE_DECISION_REASONS_MAX_REASON_LEN,
+                            subObjectName + "DecisionReasons:Reason",
+                            validationErrors);
+                }
+            }
+
+            if (JsonValidationUtility.validateListDataEmptyIsAllowed(
+                    overallResponse.getRecommendedNextActions(),
+                    "RecommendedNextActions",
+                    validationErrors)) {
+                for (String nextAction : overallResponse.getRecommendedNextActions()) {
+                    JsonValidationUtility.validateStringDataEmptyIsAllowed(
+                            nextAction,
+                            OVERALL_RESPONSE_RECOMMENDED_NEXT_ACTIONS_NEXT_ACTION_MAX_LEN,
+                            subObjectName + "RecommendedNextActions:Action",
+                            validationErrors);
+                }
+            }
+
+            if (JsonValidationUtility.validateListDataEmptyIsAllowed(
+                    overallResponse.getSpareObjects(), "SpareObjects", validationErrors)) {
+                for (String spareObject : overallResponse.getSpareObjects()) {
+                    JsonValidationUtility.validateStringDataEmptyIsAllowed(
+                            spareObject,
+                            OVERALL_RESPONSE_RECOMMENDED_SPARE_OBJECTS_SPARE_OBJECT_MAX_LEN,
+                            subObjectName + "SpareObjects:Object",
+                            validationErrors);
+                }
+            }
+        } else {
+            validationErrors.add(NULL_HEADER_OVERALL_RESPONSE_ERROR_MESSAGE);
+        }
+    }
+
+    private void validateIdentityVerificationResponseClientResponsePayload(
+            ClientResponsePayload payload, final List<String> validationErrors) {
+
+        if (payload == null) {
+            validationErrors.add(NULL_CLIENT_RESPONSE_PAYLOAD_ERROR_MESSAGE);
+            return;
+        }
+
+        List<OrchestrationDecision> orchestrationDecisions = payload.getOrchestrationDecisions();
+        if (JsonValidationUtility.validateListDataEmptyIsFail(
+                orchestrationDecisions, "OrchestrationDecisions", validationErrors)) {
+            for (OrchestrationDecision orchestrationDecision : orchestrationDecisions) {
+                validateIdentityVerificationResponseClientResponsePayloadOrchestrationDecision(
+                        orchestrationDecision, validationErrors);
+            }
+        }
+
+        List<DecisionElement> decisionElements = payload.getDecisionElements();
+        if (JsonValidationUtility.validateListDataEmptyIsFail(
+                decisionElements, "DecisionElements", validationErrors)) {
+            for (DecisionElement decisionElement : decisionElements) {
+                validateIdentityVerificationResponseClientResponsePayloadDecisionElement(
+                        decisionElement, validationErrors);
+            }
+        }
+    }
+
+    private void validateIdentityVerificationResponseClientResponsePayloadOrchestrationDecision(
+            OrchestrationDecision orchestrationDecision, List<String> validationErrors) {
+        if (orchestrationDecision == null) {
+            validationErrors.add("OrchestrationDecision is null");
+            return;
+        }
+
+        String subObjectName = "OrchestrationDecision:";
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                orchestrationDecision.getSequenceId(),
+                ORCHESTRATION_DECISION_SEQUENCE_ID_MAX_LEN,
+                subObjectName + "SequenceId",
+                validationErrors);
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                orchestrationDecision.getDecisionSource(),
+                ORCHESTRATION_DECISION_SOURCE_MAX_LEN,
+                subObjectName + "DecisionSource",
+                validationErrors);
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                orchestrationDecision.getDecision(),
+                ORCHESTRATION_DECISION_DECISION_MAX_LEN,
+                subObjectName + DECISION_FIELD_NAME,
+                validationErrors);
+
+        if (JsonValidationUtility.validateListDataEmptyIsFail(
+                orchestrationDecision.getDecisionReasons(),
+                subObjectName + "DecisionReasons",
+                validationErrors)) {
+            for (String reason : orchestrationDecision.getDecisionReasons()) {
+                JsonValidationUtility.validateStringDataEmptyIsFail(
+                        reason,
+                        ORCHESTRATION_DECISION_DECISION_REASONS_REASON_MAX_LEN,
+                        subObjectName + "DecisionReasons:Reason",
+                        validationErrors);
+            }
+        }
+
+        JsonValidationUtility.validateIntegerRangeData(
+                orchestrationDecision.getScore(),
+                ORCHESTRATION_DECISION_SCORE_MIN_VALUE,
+                ORCHESTRATION_DECISION_SCORE_MAX_VALUE,
+                subObjectName + SCORE_FIELD_NAME,
+                validationErrors);
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                orchestrationDecision.getDecisionText(),
+                ORCHESTRATION_DECISION_DECISION_TEXT_MAX_LEN,
+                subObjectName + DECISION_TEXT_FIELD_NAME,
+                validationErrors);
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                orchestrationDecision.getNextAction(),
+                ORCHESTRATION_DECISION_NEXT_ACTION_MAX_LEN,
+                subObjectName + "NextAction",
+                validationErrors);
+
+        JsonValidationUtility.validateStringDataNullAndEmptyIsAllowed(
+                orchestrationDecision.getAppReference(),
+                ORCHESTRATION_DECISION_APP_REFERENCE_MAX_LEN,
+                subObjectName + "AppReference",
+                validationErrors);
+
+        JsonValidationUtility.validateTimeStampData(
+                orchestrationDecision.getDecisionTime(),
+                subObjectName + "DecisionTime",
+                validationErrors);
+    }
+
+    private void validateIdentityVerificationResponseClientResponsePayloadDecisionElement(
+            DecisionElement decisionElement, final List<String> validationErrors) {
+        if (decisionElement == null) {
+            validationErrors.add("DecisionElement is null");
+            return;
+        }
+
+        String subObjectName = "DecisionElement:";
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                decisionElement.getApplicantId(),
+                DECISION_ELEMENTS_APP_ID_MAX_LEN,
+                subObjectName + "ApplicantId",
+                validationErrors);
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                decisionElement.getServiceName(),
+                DECISION_ELEMENTS_SERVICE_NAME_MAX_LEN,
+                subObjectName + "ServiceName",
+                validationErrors);
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                decisionElement.getDecision(),
+                DECISION_ELEMENTS_DECISION_MAX_LEN,
+                subObjectName + DECISION_FIELD_NAME,
+                validationErrors);
+
+        JsonValidationUtility.validateIntegerRangeData(
+                decisionElement.getScore(),
+                DECISION_ELEMENTS_SCORE_MIN_VALUE,
+                DECISION_ELEMENTS_SCORE_MAX_VALUE,
+                subObjectName + SCORE_FIELD_NAME,
+                validationErrors);
+
+        JsonValidationUtility.validateStringDataEmptyIsAllowed(
+                decisionElement.getDecisionText(),
+                DECISION_ELEMENTS_DECISION_TEXT_MAX_LEN,
+                subObjectName + DECISION_TEXT_FIELD_NAME,
+                validationErrors);
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                decisionElement.getDecisionReason(),
+                DECISION_ELEMENTS_DECISION_REASON_MAX_LEN,
+                subObjectName + "DecisionReason",
+                validationErrors);
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                decisionElement.getAppReference(),
+                DECISION_ELEMENTS_APP_REF_MAX_LEN,
+                subObjectName + "AppReference",
+                validationErrors);
+
+        List<Rule> rules = decisionElement.getRules();
+        if (JsonValidationUtility.validateListDataEmptyIsFail(
+                rules, subObjectName + "Rules", validationErrors)) {
+            for (Rule rule : rules) {
+                placeholderValidateDecisionElementRule(rule, validationErrors);
+            }
+        }
+
+        validateIdentityVerificationResponseClientResponsePayloadDecisionElementWarningsErrors(
+                decisionElement.getWarningsErrors(), validationErrors);
+    }
+
+    /*
+     * Placeholder for stricter validation of DecisionElementRules
+     */
+    private void placeholderValidateDecisionElementRule(
+            Rule rule, final List<String> validationErrors) {
+
+        String subObjectName = "DecisionElement:Rules:Rule:";
+
+        if (rule.getRuleScore() != null) {
+            JsonValidationUtility.validateIntegerRangeData(
+                    rule.getRuleScore(),
+                    DECISION_ELEMENTS_RULE_NAME_SERVICE_LEVEL_SCORE_MIN,
+                    DECISION_ELEMENTS_RULE_NAME_SERVICE_LEVEL_SCORE_MAX,
+                    subObjectName + SCORE_FIELD_NAME,
+                    validationErrors);
+        }
+    }
+
+    private void
+            validateIdentityVerificationResponseClientResponsePayloadDecisionElementWarningsErrors(
+                    List<WarningsErrors> warningsErrors, List<String> validationErrors) {
+        if (JsonValidationUtility.validateListDataEmptyIsAllowed(
+                warningsErrors, "DecisionElement:WarningsErrors", validationErrors)) {
+            for (WarningsErrors warningError : warningsErrors) {
+
+                boolean warningErrorSafeToLog = true;
+
+                if (warningError.getResponseCode().length()
+                        > DECISION_ELEMENTS_WARNING_RESPONSE_CODE_MAX_LEN) {
+                    validationErrors.add(
+                            "DecisionElement:WarningsErrors:ResponseCode is too long.");
+
+                    warningErrorSafeToLog = false;
+                }
+                if (warningError.getResponseMessage().length()
+                        > DECISION_ELEMENTS_WARNING_RESPONSE_MESSAGE_MAX_LEN) {
+                    validationErrors.add(
+                            "DecisionElement:WarningsErrors:ResponseMessage is too long.");
+                    warningErrorSafeToLog = false;
+                }
+
+                // Only fail for ERROR responses
+                if (warningError.getResponseType() == ResponseType.ERROR) {
+                    if (warningErrorSafeToLog) {
+                        validationErrors.add(
+                                "DecisionElement:ResponseType:Error, ResponseCode:"
+                                        + warningError.getResponseCode()
+                                        + ", ResponseMessage:"
+                                        + warningError.getResponseMessage());
+                    } else {
+                        validationErrors.add(WARNINGS_ERRORS_FALL_BACK_ERROR_MESAGE);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/JsonValidationUtility.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/JsonValidationUtility.java
@@ -1,0 +1,178 @@
+package uk.gov.di.ipv.cri.fraud.api.util;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+/** Utility class used to validate JSON. */
+public final class JsonValidationUtility {
+
+    public static final String IS_NULL_ERROR_MESSAGE_SUFFIX = " not found.";
+    public static final String IS_EMPTY_ERROR_MESSAGE_SUFFIX = " is empty.";
+    public static final String IS_TOO_LONG_ERROR_MESSAGE_SUFFIX = " is too long.";
+    public static final String INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX =
+            " is outside the valid range.";
+    public static final String FAIL_PARSING_TIMESTAMP_ERROR_MESSAGE_SUFFIX =
+            " failed timestamp parsing.";
+
+    private JsonValidationUtility() {
+        throw new IllegalStateException("Instantiation is not valid for this class.");
+    }
+
+    /**
+     * Test that a list is not null.
+     *
+     * @param variable The variable being validated
+     * @param name String name of the field being validated
+     * @param validationErrors A list in which to collect validation errors
+     * @return true if validation passed or false if not.
+     */
+    public static boolean validateListDataEmptyIsAllowed(
+            List<?> variable, String name, final List<String> validationErrors) {
+        if (variable == null) {
+            validationErrors.add(name + IS_NULL_ERROR_MESSAGE_SUFFIX);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Test that a list is not null or empty.
+     *
+     * @param variable The variable being validated
+     * @param name String name of the field being validated
+     * @param validationErrors A list in which to collect validation errors
+     * @return true if validation passed or false if not.
+     */
+    public static boolean validateListDataEmptyIsFail(
+            List<?> variable, String name, final List<String> validationErrors) {
+        if (variable != null) {
+            if (variable.isEmpty()) {
+                validationErrors.add(name + IS_EMPTY_ERROR_MESSAGE_SUFFIX);
+                return false;
+            }
+        } else {
+            validationErrors.add(name + IS_NULL_ERROR_MESSAGE_SUFFIX);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Test that a String is not null, Empty or too large.
+     *
+     * @param variable The variable being validated
+     * @param name String name of the field being validated
+     * @param validationErrors A list in which to collect validation errors
+     * @return true if validation passed or false if not.
+     */
+    public static boolean validateStringDataEmptyIsFail(
+            String variable, int maxLength, String name, final List<String> validationErrors) {
+        if (variable != null) {
+            if (!variable.isBlank()) {
+                if (variable.length() > maxLength) {
+                    validationErrors.add(name + IS_TOO_LONG_ERROR_MESSAGE_SUFFIX);
+                    return false;
+                }
+            } else {
+                validationErrors.add(name + IS_EMPTY_ERROR_MESSAGE_SUFFIX);
+                return false;
+            }
+        } else {
+            validationErrors.add(name + IS_NULL_ERROR_MESSAGE_SUFFIX);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Test that a String is not null or too large.
+     *
+     * @param variable The variable being validated
+     * @param name String name of the field being validated
+     * @param validationErrors A list in which to collect validation errors
+     * @return true if validation passed or false if not.
+     */
+    public static boolean validateStringDataEmptyIsAllowed(
+            String variable, int maxLength, String name, final List<String> validationErrors) {
+        if (variable != null) {
+            if (variable.length() > maxLength) {
+                validationErrors.add(name + IS_TOO_LONG_ERROR_MESSAGE_SUFFIX);
+                return false;
+            }
+        } else {
+            validationErrors.add(name + IS_NULL_ERROR_MESSAGE_SUFFIX);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Test a String which can be null.
+     *
+     * @param variable The variable being validated
+     * @param name String name of the field being validated
+     * @param validationErrors A list in which to collect validation errors
+     * @return true if validation passed or false if not.
+     */
+    public static boolean validateStringDataNullAndEmptyIsAllowed(
+            String variable, int maxLength, String name, final List<String> validationErrors) {
+        if (variable != null && (variable.length() > maxLength)) {
+            validationErrors.add(name + IS_TOO_LONG_ERROR_MESSAGE_SUFFIX);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Test that a Timestamp held in a string can be parsed.
+     *
+     * @param variable The variable being validated
+     * @param name String name of the field being validated
+     * @param validationErrors A list in which to collect validation errors
+     * @return true if validation passed or false if not.
+     */
+    public static boolean validateTimeStampData(
+            String variable, String name, final List<String> validationErrors) {
+        if (variable != null) {
+            if (!variable.isBlank()) {
+                try {
+                    Instant.parse(variable);
+                } catch (DateTimeParseException e) {
+                    validationErrors.add(name + FAIL_PARSING_TIMESTAMP_ERROR_MESSAGE_SUFFIX);
+                    return false;
+                }
+            } else {
+                validationErrors.add(name + IS_EMPTY_ERROR_MESSAGE_SUFFIX);
+                return false;
+            }
+        } else {
+            validationErrors.add(name + IS_NULL_ERROR_MESSAGE_SUFFIX);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Test that a value held in an integer is within the range min - max (inclusive).
+     *
+     * @param variable The variable being validated
+     * @param name String name of the field being validated
+     * @param validationErrors A list in which to collect validation errors
+     * @return true if validation passed or false if not.
+     */
+    public static boolean validateIntegerRangeData(
+            int variable, int min, int max, String name, final List<String> validationErrors) {
+        if (variable < min || variable > max) {
+            validationErrors.add(name + INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationResponseMapperTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationResponseMapperTest.java
@@ -3,12 +3,12 @@ package uk.gov.di.ipv.cri.fraud.api.gateway;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.cri.fraud.api.domain.FraudCheckResult;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.ClientResponsePayload;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.DecisionElement;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.IdentityVerificationResponse;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.ResponseHeader;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.ResponseType;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.Rule;
+import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
 
 import java.util.List;
 
@@ -53,20 +53,19 @@ class IdentityVerificationResponseMapperTest {
     @Test
     void mapIdentityVerificationResponseShouldMapInfoResponse() {
         IdentityVerificationResponse testIdentityVerificationResponse =
-                new IdentityVerificationResponse();
-        ResponseHeader responseHeader = new ResponseHeader();
-        responseHeader.setResponseType(ResponseType.INFO);
-        testIdentityVerificationResponse.setResponseHeader(responseHeader);
+                TestDataCreator.createTestVerificationInfoResponse();
 
-        DecisionElement decisionElement = new DecisionElement();
+        DecisionElement decisionElement =
+                testIdentityVerificationResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0);
         Rule rule = new Rule();
+        rule.setRuleName("");
         rule.setRuleId("rule01");
+        rule.setRuleText("Test Rule");
         List<Rule> rules = List.of(rule);
         decisionElement.setRules(rules);
-
-        ClientResponsePayload responsePayload = new ClientResponsePayload();
-        responsePayload.setDecisionElements(List.of(decisionElement));
-        testIdentityVerificationResponse.setClientResponsePayload(responsePayload);
 
         FraudCheckResult fraudCheckResult =
                 this.responseMapper.mapIdentityVerificationResponse(

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
@@ -1,0 +1,3091 @@
+package uk.gov.di.ipv.cri.fraud.api.service;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.cri.fraud.api.domain.ValidationResult;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.IdentityVerificationResponse;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.ResponseType;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.Rule;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.WarningsErrors;
+import uk.gov.di.ipv.cri.fraud.api.util.JsonValidationUtility;
+import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IdentityVerificationInfoResponseValidatorTest {
+    private static IdentityVerificationInfoResponseValidator infoResponseValidator;
+    private static IdentityVerificationResponse testIVResponse;
+    private static final String len10String = "0123456789";
+
+    @BeforeAll
+    public static void GlobalSetup() {
+        infoResponseValidator = new IdentityVerificationInfoResponseValidator();
+    }
+
+    @BeforeEach
+    public void PreEachTestSetup() {
+        testIVResponse = TestDataCreator.createTestVerificationInfoResponse();
+    }
+
+    @Test
+    void nullResponseIsAnError() {
+        ValidationResult<List<String>> validationResult = infoResponseValidator.validate(null);
+
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(
+                IdentityVerificationInfoResponseValidator.NULL_RESPONSE_ERROR_MESSAGE,
+                validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void testResponseCanBeValidated() {
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerCannotBeNULL() {
+        testIVResponse.setResponseHeader(null);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(
+                IdentityVerificationInfoResponseValidator.NULL_HEADER_ERROR_MESSAGE,
+                validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerTenantIDCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(3) + "1";
+        testIVResponse.getResponseHeader().setTenantID(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "TenantID" + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getTenantID());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerTenantIDMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(3);
+        testIVResponse.getResponseHeader().setTenantID(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getTenantID());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerTenantIDCannotBeBlank() {
+        final String TEST_STRING = "";
+        testIVResponse.getResponseHeader().setTenantID(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "TenantID" + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(testIVResponse.getResponseHeader().getTenantID(), TEST_STRING);
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerRequestTypeCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(4) + "1";
+        testIVResponse.getResponseHeader().setRequestType(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "RequestType" + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getRequestType());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerRequestTypeMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(4);
+        testIVResponse.getResponseHeader().setRequestType(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getRequestType());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerRequestTypeCannotBeBlank() {
+        final String TEST_STRING = "";
+        testIVResponse.getResponseHeader().setRequestType(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "RequestType" + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(testIVResponse.getResponseHeader().getRequestType(), TEST_STRING);
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerClientReferenceIdCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(9) + "1";
+        testIVResponse.getResponseHeader().setClientReferenceId(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "ClientReferenceId" + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getClientReferenceId());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerClientReferenceIdMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(4);
+        testIVResponse.getResponseHeader().setClientReferenceId(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getClientReferenceId());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerClientReferenceIdCannotBeEmpty() {
+        final String TEST_STRING = "";
+        testIVResponse.getResponseHeader().setClientReferenceId(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "ClientReferenceId" + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getClientReferenceId());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerExpRequestIdCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(9) + "1";
+        testIVResponse.getResponseHeader().setExpRequestId(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "ExpRequestId" + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getExpRequestId());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerExpRequestIdMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(9);
+        testIVResponse.getResponseHeader().setExpRequestId(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getExpRequestId());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerExpRequestIdCannotBeEmpty() {
+        final String TEST_STRING = "";
+        testIVResponse.getResponseHeader().setExpRequestId(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "ExpRequestId" + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getExpRequestId());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerMessageTimeFailsIfNull() {
+        final String TEST_STRING = null;
+        testIVResponse.getResponseHeader().setMessageTime(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "MessageTime" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+
+        assertNull(testIVResponse.getResponseHeader().getMessageTime());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerMessageTimeFailsIfEmpty() {
+        final String TEST_STRING = "";
+        testIVResponse.getResponseHeader().setMessageTime(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "MessageTime" + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getMessageTime());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerMessageTimeFailsIfInvalid() {
+        final String TEST_STRING = "123";
+        testIVResponse.getResponseHeader().setMessageTime(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "MessageTime" + JsonValidationUtility.FAIL_PARSING_TIMESTAMP_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getMessageTime());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerMessageValidTimeCanBeParsed() {
+        final String TEST_STRING = "2022-01-01T00:00:01Z";
+        testIVResponse.getResponseHeader().setMessageTime(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getMessageTime());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseCannotBeNull() {
+        testIVResponse.getResponseHeader().setOverallResponse(null);
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertNull(testIVResponse.getResponseHeader().getOverallResponse());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(
+                IdentityVerificationInfoResponseValidator
+                        .NULL_HEADER_OVERALL_RESPONSE_ERROR_MESSAGE,
+                validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void testHeaderOverallResponseDecisionCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(1) + "1";
+
+        testIVResponse.getResponseHeader().getOverallResponse().setDecision(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OverallResponse:Decision" + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING, testIVResponse.getResponseHeader().getOverallResponse().getDecision());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void testHeaderOverallResponseDecisionMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(1);
+        testIVResponse.getResponseHeader().getOverallResponse().setDecision(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING, testIVResponse.getResponseHeader().getOverallResponse().getDecision());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseDecisionCannotEmpty() {
+        final String TEST_STRING = "";
+        testIVResponse.getResponseHeader().getOverallResponse().setDecision(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OverallResponse:Decision" + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING, testIVResponse.getResponseHeader().getOverallResponse().getDecision());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseDecisionScoreUnderMinFails() {
+        final int TEST_VALUE = -1;
+        testIVResponse.getResponseHeader().getOverallResponse().setScore(TEST_VALUE);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OverallResponse:Score"
+                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_VALUE, testIVResponse.getResponseHeader().getOverallResponse().getScore());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseDecisionScoreMinOK() {
+        final int TEST_VALUE = 0;
+        testIVResponse.getResponseHeader().getOverallResponse().setScore(TEST_VALUE);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_VALUE, testIVResponse.getResponseHeader().getOverallResponse().getScore());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseDecisionScoreMaxOK() {
+        final int TEST_VALUE = 99999;
+        testIVResponse.getResponseHeader().getOverallResponse().setScore(TEST_VALUE);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_VALUE, testIVResponse.getResponseHeader().getOverallResponse().getScore());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseDecisionScoreOverMaxFails() {
+        final int TEST_VALUE = 100000;
+        testIVResponse.getResponseHeader().getOverallResponse().setScore(TEST_VALUE);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OverallResponse:Score"
+                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_VALUE, testIVResponse.getResponseHeader().getOverallResponse().getScore());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseDecisionTextCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(3) + "1";
+
+        testIVResponse.getResponseHeader().getOverallResponse().setDecisionText(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OverallResponse:DecisionText"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse.getResponseHeader().getOverallResponse().getDecisionText());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseDecisionTextMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(3);
+
+        testIVResponse.getResponseHeader().getOverallResponse().setDecisionText(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse.getResponseHeader().getOverallResponse().getDecisionText());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseDecisionTextCannotBeEmpty() {
+        final String TEST_STRING = "";
+        testIVResponse.getResponseHeader().getOverallResponse().setDecisionText(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OverallResponse:DecisionText"
+                        + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse.getResponseHeader().getOverallResponse().getDecisionText());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseDecisionReasonsCannotBeEmpty() {
+        testIVResponse
+                .getResponseHeader()
+                .getOverallResponse()
+                .setDecisionReasons(new ArrayList<>());
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OverallResponse:DecisionReasons"
+                        + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                0,
+                testIVResponse
+                        .getResponseHeader()
+                        .getOverallResponse()
+                        .getDecisionReasons()
+                        .size());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseDecisionReasonsReasonCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(9) + "1";
+        testIVResponse
+                .getResponseHeader()
+                .getOverallResponse()
+                .setDecisionReasons(List.of(TEST_STRING));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OverallResponse:DecisionReasons:Reason"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getResponseHeader()
+                        .getOverallResponse()
+                        .getDecisionReasons()
+                        .size());
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getResponseHeader()
+                        .getOverallResponse()
+                        .getDecisionReasons()
+                        .get(0));
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseDecisionReasonsReasonMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(9);
+        testIVResponse
+                .getResponseHeader()
+                .getOverallResponse()
+                .setDecisionReasons(List.of(TEST_STRING));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getResponseHeader()
+                        .getOverallResponse()
+                        .getDecisionReasons()
+                        .size());
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getResponseHeader()
+                        .getOverallResponse()
+                        .getDecisionReasons()
+                        .get(0));
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseDecisionReasonsReasonCannotBeEmpty() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getResponseHeader()
+                .getOverallResponse()
+                .setDecisionReasons(List.of(TEST_STRING));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OverallResponse:DecisionReasons:Reason"
+                        + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getResponseHeader()
+                        .getOverallResponse()
+                        .getDecisionReasons()
+                        .size());
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getResponseHeader()
+                        .getOverallResponse()
+                        .getDecisionReasons()
+                        .get(0));
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseRecommendedNextActionsEmptyIsOK() {
+        testIVResponse
+                .getResponseHeader()
+                .getOverallResponse()
+                .setRecommendedNextActions(new ArrayList<>());
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                0,
+                testIVResponse
+                        .getResponseHeader()
+                        .getOverallResponse()
+                        .getRecommendedNextActions()
+                        .size());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseRecommendedNextActionsActionCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(20) + "1";
+        testIVResponse
+                .getResponseHeader()
+                .getOverallResponse()
+                .setRecommendedNextActions(List.of(TEST_STRING));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OverallResponse:RecommendedNextActions:Action"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getResponseHeader()
+                        .getOverallResponse()
+                        .getRecommendedNextActions()
+                        .size());
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getResponseHeader()
+                        .getOverallResponse()
+                        .getRecommendedNextActions()
+                        .get(0));
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseRecommendedNextActionsActionMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(20);
+        testIVResponse
+                .getResponseHeader()
+                .getOverallResponse()
+                .setRecommendedNextActions(List.of(TEST_STRING));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getResponseHeader()
+                        .getOverallResponse()
+                        .getRecommendedNextActions()
+                        .size());
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getResponseHeader()
+                        .getOverallResponse()
+                        .getRecommendedNextActions()
+                        .get(0));
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseRecommendedNextActionsEmptyActionIsOK() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getResponseHeader()
+                .getOverallResponse()
+                .setRecommendedNextActions(List.of(TEST_STRING));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getResponseHeader()
+                        .getOverallResponse()
+                        .getRecommendedNextActions()
+                        .size());
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getResponseHeader()
+                        .getOverallResponse()
+                        .getRecommendedNextActions()
+                        .get(0));
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseSpareObjectsEmptyIsOK() {
+        testIVResponse.getResponseHeader().getOverallResponse().setSpareObjects(new ArrayList<>());
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                0,
+                testIVResponse.getResponseHeader().getOverallResponse().getSpareObjects().size());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseSpareObjectsObjectCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(20) + "1";
+        testIVResponse
+                .getResponseHeader()
+                .getOverallResponse()
+                .setSpareObjects(List.of(TEST_STRING));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OverallResponse:SpareObjects:Object"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                1,
+                testIVResponse.getResponseHeader().getOverallResponse().getSpareObjects().size());
+        assertEquals(
+                TEST_STRING,
+                testIVResponse.getResponseHeader().getOverallResponse().getSpareObjects().get(0));
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseSpareObjectsObjectMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(20);
+        testIVResponse
+                .getResponseHeader()
+                .getOverallResponse()
+                .setSpareObjects(List.of(TEST_STRING));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse.getResponseHeader().getOverallResponse().getSpareObjects().size());
+        assertEquals(
+                TEST_STRING,
+                testIVResponse.getResponseHeader().getOverallResponse().getSpareObjects().get(0));
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerOverallResponseSpareObjectsObjectEmptyIsOK() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getResponseHeader()
+                .getOverallResponse()
+                .setSpareObjects(List.of(TEST_STRING));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse.getResponseHeader().getOverallResponse().getSpareObjects().size());
+        assertEquals(
+                TEST_STRING,
+                testIVResponse.getResponseHeader().getOverallResponse().getSpareObjects().get(0));
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerResponseCodeCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(2) + "1";
+        testIVResponse.getResponseHeader().setResponseCode(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "ResponseCode" + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getResponseCode());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerResponseCodeMaxLenOK() {
+        testIVResponse.getResponseHeader().setResponseCode(len10String.repeat(2));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        System.out.println(validationResult.getError());
+
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerResponseCodeCannotBeEmpty() {
+        final String TEST_STRING = "";
+        testIVResponse.getResponseHeader().setResponseCode(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "ResponseCode" + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getResponseCode());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerResponseTypeInfoIsOK() {
+        final ResponseType type = ResponseType.INFO;
+        testIVResponse.getResponseHeader().setResponseType(type);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(type, testIVResponse.getResponseHeader().getResponseType());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerResponseTypeNullIsFail() {
+        final ResponseType type = null;
+        testIVResponse.getResponseHeader().setResponseType(type);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                IdentityVerificationInfoResponseValidator.RESPONSE_TYPE_ERROR_MESSAGE + type;
+
+        assertNull(testIVResponse.getResponseHeader().getResponseType());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerResponseTypeErrorIsFail() {
+        final ResponseType type = ResponseType.ERROR;
+        testIVResponse.getResponseHeader().setResponseType(type);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                IdentityVerificationInfoResponseValidator.RESPONSE_TYPE_ERROR_MESSAGE + type;
+
+        assertEquals(type, testIVResponse.getResponseHeader().getResponseType());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerResponseTypeWarnIsFail() {
+        final ResponseType type = ResponseType.WARN;
+        testIVResponse.getResponseHeader().setResponseType(type);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                IdentityVerificationInfoResponseValidator.RESPONSE_TYPE_ERROR_MESSAGE + type;
+
+        assertEquals(type, testIVResponse.getResponseHeader().getResponseType());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerResponseTypeWarningIsFail() {
+        final ResponseType type = ResponseType.WARNING;
+        testIVResponse.getResponseHeader().setResponseType(type);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                IdentityVerificationInfoResponseValidator.RESPONSE_TYPE_ERROR_MESSAGE + type;
+
+        assertEquals(type, testIVResponse.getResponseHeader().getResponseType());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerResponseMessageCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(30) + "1";
+        testIVResponse.getResponseHeader().setResponseMessage(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "ResponseMessage" + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getResponseMessage());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void headerResponseMessageMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(30);
+        testIVResponse.getResponseHeader().setResponseMessage(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getResponseMessage());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void headerResponseMessageCannotBeEmpty() {
+        final String TEST_STRING = "";
+        testIVResponse.getResponseHeader().setResponseMessage(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "ResponseMessage" + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(TEST_STRING, testIVResponse.getResponseHeader().getResponseMessage());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadCannotBeNULL() {
+        testIVResponse.setClientResponsePayload(null);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                IdentityVerificationInfoResponseValidator
+                        .NULL_CLIENT_RESPONSE_PAYLOAD_ERROR_MESSAGE;
+
+        assertNull(testIVResponse.getClientResponsePayload());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsCannotBeNull() {
+        testIVResponse.getClientResponsePayload().setOrchestrationDecisions(null);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecisions" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+
+        assertNull(testIVResponse.getClientResponsePayload().getOrchestrationDecisions());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsCannotBeEmpty() {
+        testIVResponse.getClientResponsePayload().setOrchestrationDecisions(new ArrayList<>());
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecisions" + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                0, testIVResponse.getClientResponsePayload().getOrchestrationDecisions().size());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationDecisionSequenceIdCannotBeEmpty() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setSequenceId(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:SequenceId"
+                        + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getSequenceId());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationDecisionSequenceIdCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(4) + "1";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setSequenceId(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:SequenceId"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getSequenceId());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationDecisionSequenceIdMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(4);
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setSequenceId(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getSequenceId());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationDecisionSourceCannotBeEmpty() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecisionSource(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:DecisionSource"
+                        + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionSource());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationDecisionSourceCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(2) + "1";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecisionSource(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:DecisionSource"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionSource());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationDecisionSourceMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(2);
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecisionSource(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionSource());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationDecisionDecisionCannotBeEmpty() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecision(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:Decision"
+                        + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecision());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationDecisionDecisionCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(1) + "1";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecision(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:Decision"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecision());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationDecisionDecisionMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(1);
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecision(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecision());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsReasonsCannotBeNull() {
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecisionReasons(null);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:DecisionReasons"
+                        + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+
+        assertNull(
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionReasons());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsReasonsCannotBeEmpty() {
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecisionReasons(new ArrayList<>());
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:DecisionReasons"
+                        + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                0,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionReasons()
+                        .size());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsReasonsReasonCannotBeEmpty() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecisionReasons(List.of(TEST_STRING));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:DecisionReasons:Reason"
+                        + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionReasons()
+                        .size());
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionReasons()
+                        .get(0));
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsReasonsReasonCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(9) + 1;
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecisionReasons(List.of(TEST_STRING));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:DecisionReasons:Reason"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionReasons()
+                        .size());
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionReasons()
+                        .get(0));
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsReasonsReasonMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(9);
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecisionReasons(List.of(TEST_STRING));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionReasons()
+                        .size());
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionReasons()
+                        .get(0));
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsScoreUnderMinFails() {
+        final int TEST_VALUE = -1;
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setScore(TEST_VALUE);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:Score"
+                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_VALUE,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getScore());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsMinOK() {
+        final int TEST_VALUE = 0;
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setScore(TEST_VALUE);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_VALUE,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getScore());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOverMaxFails() {
+        final int TEST_VALUE = 100000;
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setScore(TEST_VALUE);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:Score"
+                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_VALUE,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getScore());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsMaxOK() {
+        final int TEST_VALUE = 99999;
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setScore(TEST_VALUE);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_VALUE,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getScore());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationDecisionTextCannotBeEmpty() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecisionText(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:DecisionText"
+                        + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionText());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationDecisionTextCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(3) + "1";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecisionText(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:DecisionText"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionText());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationDecisionTextMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(3);
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecisionText(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionText());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationNextActionCannotBeEmpty() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setNextAction(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:NextAction"
+                        + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getNextAction());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationNextActionCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(2) + "1";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setNextAction(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:NextAction"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getNextAction());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationNextActionMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(2);
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setNextAction(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getNextAction());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationAppReferenceNullIsAllowed() {
+        final String TEST_STRING = null;
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setAppReference(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getAppReference());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationAppReferenceEmptyIsAllowed() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setAppReference(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getAppReference());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationAppReferenceCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(2) + "1";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setAppReference(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:AppReference"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getAppReference());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationAppReferenceMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(2);
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setAppReference(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getAppReference());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationDecisionTimeFailsIfEmpty() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecisionTime(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:DecisionTime"
+                        + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionTime());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationDecisionTimeFailsIfInvalid() {
+        final String TEST_STRING = "123";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecisionTime(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "OrchestrationDecision:DecisionTime"
+                        + JsonValidationUtility.FAIL_PARSING_TIMESTAMP_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionTime());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadOrchestrationDecisionsOrchestrationDecisionTimeCanBeParsed() {
+        final String TEST_STRING = "2022-01-01T00:00:01Z";
+        testIVResponse
+                .getClientResponsePayload()
+                .getOrchestrationDecisions()
+                .get(0)
+                .setDecisionTime(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getOrchestrationDecisions()
+                        .get(0)
+                        .getDecisionTime());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsCannotBeNull() {
+        testIVResponse.getClientResponsePayload().setDecisionElements(null);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElements" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+
+        assertNull(testIVResponse.getClientResponsePayload().getDecisionElements());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsCannotBeEmpty() {
+        testIVResponse.getClientResponsePayload().setDecisionElements(new ArrayList<>());
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElements" + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(0, testIVResponse.getClientResponsePayload().getDecisionElements().size());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementApplicantIdEmptyIsFail() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setApplicantId(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:ApplicantId" + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getApplicantId());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementApplicantIdCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(4) + "1";
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setApplicantId(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:ApplicantId"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getApplicantId());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementApplicantIdMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(4);
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setApplicantId(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getApplicantId());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementServiceNameEmptyIsFail() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setServiceName(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:ServiceName" + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getServiceName());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementServiceNameCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(4) + "1";
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setServiceName(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:ServiceName"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getServiceName());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementServiceNameMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(4);
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setServiceName(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getServiceName());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementDecisionEmptyIsFail() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setDecision(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:Decision" + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getDecision());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementDecisionCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(2) + "1";
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setDecision(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:Decision" + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getDecision());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementDecisionMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(2);
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setDecision(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getDecision());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementScoreUnderMinFails() {
+        final int TEST_VALUE = -1;
+        testIVResponse.getClientResponsePayload().getDecisionElements().get(0).setScore(TEST_VALUE);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:Score"
+                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_VALUE,
+                testIVResponse.getClientResponsePayload().getDecisionElements().get(0).getScore());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementScoreMinOK() {
+        final int TEST_VALUE = 0;
+        testIVResponse.getClientResponsePayload().getDecisionElements().get(0).setScore(TEST_VALUE);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_VALUE,
+                testIVResponse.getClientResponsePayload().getDecisionElements().get(0).getScore());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementScoreOverMaxFails() {
+        final int TEST_VALUE = 91;
+        testIVResponse.getClientResponsePayload().getDecisionElements().get(0).setScore(TEST_VALUE);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:Score"
+                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_VALUE,
+                testIVResponse.getClientResponsePayload().getDecisionElements().get(0).getScore());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementScoreMaxOK() {
+        final int TEST_VALUE = 90;
+        testIVResponse.getClientResponsePayload().getDecisionElements().get(0).setScore(TEST_VALUE);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_VALUE,
+                testIVResponse.getClientResponsePayload().getDecisionElements().get(0).getScore());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementDecisionTextEmptyIsOK() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setDecisionText(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getDecisionText());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementDecisionTextCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(2) + "1";
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setDecisionText(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:DecisionText"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getDecisionText());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementDecisionTextMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(2);
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setDecisionText(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getDecisionText());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementDecisionReasonEmptyIsFail() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setDecisionReason(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:DecisionReason"
+                        + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getDecisionReason());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementDecisionReasonCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(10) + "1";
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setDecisionReason(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:DecisionReason"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getDecisionReason());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementDecisionReasonMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(10);
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setDecisionReason(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getDecisionReason());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementAppReferenceEmptyIsFail() {
+        final String TEST_STRING = "";
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setAppReference(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:AppReference"
+                        + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getAppReference());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementAppReferenceCannotBeTooLong() {
+        final String TEST_STRING = len10String.repeat(10) + "1";
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setAppReference(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:AppReference"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getAppReference());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementAppReferenceMaxLenOK() {
+        final String TEST_STRING = len10String.repeat(10);
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setAppReference(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                TEST_STRING,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getAppReference());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementRulesNullIsFail() {
+        testIVResponse.getClientResponsePayload().getDecisionElements().get(0).setRules(null);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:Rules" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+
+        assertNull(
+                testIVResponse.getClientResponsePayload().getDecisionElements().get(0).getRules());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementRulesEmptyIsFail() {
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setRules(new ArrayList<>());
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:Rules" + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                0,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getRules()
+                        .size());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementRuleScoreUnderMinFails() {
+        final Rule testRule = new Rule();
+        testRule.setRuleName("ScoreUnderMinFail");
+        testRule.setRuleId("");
+        testRule.setRuleScore(-1);
+        testRule.setRuleText("Test");
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setRules(List.of(testRule));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:Rules:Rule:Score"
+                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getRules()
+                        .size());
+        assertEquals(
+                testRule,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getRules()
+                        .get(0));
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementRuleScoreMinOK() {
+        final Rule testRule = new Rule();
+        testRule.setRuleName("ScoreUnderMinFail");
+        testRule.setRuleId("");
+        testRule.setRuleScore(0);
+        testRule.setRuleText("Test");
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setRules(List.of(testRule));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getRules()
+                        .size());
+        assertEquals(
+                testRule,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getRules()
+                        .get(0));
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementRuleScoreOverMaxFails() {
+        final Rule testRule = new Rule();
+        testRule.setRuleName("ScoreUnderMinFail");
+        testRule.setRuleId("");
+        testRule.setRuleScore(91);
+        testRule.setRuleText("Test");
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setRules(List.of(testRule));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:Rules:Rule:Score"
+                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getRules()
+                        .size());
+        assertEquals(
+                testRule,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getRules()
+                        .get(0));
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementRuleScoreMaxOK() {
+        final Rule testRule = new Rule();
+        testRule.setRuleName("ScoreUnderMinFail");
+        testRule.setRuleId("");
+        testRule.setRuleScore(90);
+        testRule.setRuleText("Test");
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setRules(List.of(testRule));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getRules()
+                        .size());
+        assertEquals(
+                testRule,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getRules()
+                        .get(0));
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementWarningsErrorsNullIsFail() {
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setWarningsErrors(null);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:WarningsErrors"
+                        + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+
+        assertNull(
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementWarningsErrorsEmptyIsOK() {
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setWarningsErrors(new ArrayList<>());
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                0,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .size());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseCodeMaxLenOK() {
+        final WarningsErrors warningError = new WarningsErrors();
+        warningError.setResponseCode(len10String.repeat(4));
+        warningError.setResponseMessage("Message");
+        warningError.setResponseType(ResponseType.INFO);
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setWarningsErrors(List.of(warningError));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .size());
+        assertEquals(
+                warningError,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .get(0));
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseCodeCannotBeTooLong() {
+        final WarningsErrors warningError = new WarningsErrors();
+        warningError.setResponseCode(len10String.repeat(4) + "1");
+        warningError.setResponseMessage("Message");
+        warningError.setResponseType(ResponseType.INFO);
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setWarningsErrors(List.of(warningError));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:WarningsErrors:ResponseCode"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .size());
+        assertEquals(
+                warningError,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .get(0));
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseMessageMaxLenOK() {
+        final WarningsErrors warningError = new WarningsErrors();
+        warningError.setResponseCode("1");
+        warningError.setResponseMessage(len10String.repeat(30));
+        warningError.setResponseType(ResponseType.INFO);
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setWarningsErrors(List.of(warningError));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .size());
+        assertEquals(
+                warningError,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .get(0));
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void
+            clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseMessageCannotBeTooLong() {
+        final WarningsErrors warningError = new WarningsErrors();
+        warningError.setResponseCode("1");
+        warningError.setResponseMessage(len10String.repeat(30) + "1");
+        warningError.setResponseType(ResponseType.INFO);
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setWarningsErrors(List.of(warningError));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:WarningsErrors:ResponseMessage"
+                        + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .size());
+        assertEquals(
+                warningError,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .get(0));
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void
+            clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseTypeErrorIsFailWithSafeToLogWarningError() {
+        WarningsErrors warningError = new WarningsErrors();
+        warningError.setResponseCode("1");
+        warningError.setResponseMessage("Message");
+        warningError.setResponseType(ResponseType.ERROR);
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setWarningsErrors(List.of(warningError));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                "DecisionElement:ResponseType:Error, ResponseCode:"
+                        + warningError.getResponseCode()
+                        + ", ResponseMessage:"
+                        + warningError.getResponseMessage();
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .size());
+        assertEquals(
+                warningError,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .get(0));
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void
+            clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseTypeErrorIsFailWithUnSafeToLogWarningErrorResponseCode() {
+        WarningsErrors warningError = new WarningsErrors();
+        final String CODE = len10String.repeat(4) + "1";
+        warningError.setResponseCode(CODE);
+        warningError.setResponseMessage("Message");
+        warningError.setResponseType(ResponseType.ERROR);
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setWarningsErrors(List.of(warningError));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                IdentityVerificationInfoResponseValidator.WARNINGS_ERRORS_FALL_BACK_ERROR_MESAGE;
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .size());
+        assertEquals(
+                warningError,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .get(0));
+        // Two errors 1 for the field and one for the Type
+        assertEquals(2, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(1));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void
+            clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseTypeErrorIsFailWithUnSafeToLogWarningErrorResponseMessage() {
+        WarningsErrors warningError = new WarningsErrors();
+        final String MESSAGE = len10String.repeat(30) + "1";
+        warningError.setResponseCode("1");
+        warningError.setResponseMessage(MESSAGE);
+        warningError.setResponseType(ResponseType.ERROR);
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setWarningsErrors(List.of(warningError));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                IdentityVerificationInfoResponseValidator.WARNINGS_ERRORS_FALL_BACK_ERROR_MESAGE;
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .size());
+        assertEquals(
+                warningError,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .get(0));
+        // Two errors 1 for the field and one for the Type
+        assertEquals(2, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(1));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseTypeInfoIsOK() {
+        final WarningsErrors warningError = new WarningsErrors();
+        warningError.setResponseCode("1");
+        warningError.setResponseMessage("Message");
+        warningError.setResponseType(ResponseType.INFO);
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setWarningsErrors(List.of(warningError));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .size());
+        assertEquals(
+                warningError,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .get(0));
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseTypeWarnIsOK() {
+        WarningsErrors warningError = new WarningsErrors();
+        warningError.setResponseCode("1");
+        warningError.setResponseMessage("Message");
+        warningError.setResponseType(ResponseType.WARN);
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setWarningsErrors(List.of(warningError));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .size());
+        assertEquals(
+                warningError,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .get(0));
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseTypeWarningIsOK() {
+        WarningsErrors warningError = new WarningsErrors();
+        warningError.setResponseCode("1");
+        warningError.setResponseMessage("Message");
+        warningError.setResponseType(ResponseType.WARNING);
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setWarningsErrors(List.of(warningError));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .size());
+        assertEquals(
+                warningError,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .get(0));
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+}

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java
@@ -3,8 +3,10 @@ package uk.gov.di.ipv.cri.fraud.api.util;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 import static uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType.CURRENT;
@@ -28,5 +30,75 @@ public class TestDataCreator {
 
     public static PersonIdentity createTestPersonIdentity() {
         return createTestPersonIdentity(CURRENT);
+    }
+
+    public static IdentityVerificationResponse createTestVerificationInfoResponse() {
+        IdentityVerificationResponse testIVR = new IdentityVerificationResponse();
+
+        ResponseHeader header = new ResponseHeader();
+        header.setRequestType("TEST_INFO_REQUEST");
+        header.setClientReferenceId("1234567890abcdefghijklmnopqrstuvwxyz");
+        header.setExpRequestId("1234");
+        header.setMessageTime("2022-01-01T00:00:01Z");
+
+        OverallResponse overallResponse = new OverallResponse();
+        overallResponse.setDecision("OK");
+        overallResponse.setDecisionText("OK");
+        overallResponse.setDecisionReasons(List.of("NoReason"));
+        overallResponse.setRecommendedNextActions(List.of(""));
+        overallResponse.setSpareObjects(List.of(""));
+        header.setOverallResponse(overallResponse);
+
+        header.setResponseCode("1234");
+        header.setResponseType(ResponseType.INFO);
+        header.setResponseMessage("Text");
+        header.setTenantID("1234");
+
+        testIVR.setResponseHeader(header);
+
+        ClientResponsePayload payload = new ClientResponsePayload();
+
+        List<OrchestrationDecision> orchestrationDecisions = new ArrayList<>();
+        OrchestrationDecision orchestrationDecision1 = new OrchestrationDecision();
+        orchestrationDecision1.setSequenceId("1");
+        orchestrationDecision1.setDecisionSource("Test");
+        orchestrationDecision1.setDecision("OK");
+        orchestrationDecision1.setDecisionReasons(List.of("Test"));
+        orchestrationDecision1.setScore(0);
+        orchestrationDecision1.setDecisionText("Test");
+        orchestrationDecision1.setDecisionTime("2022-01-01T00:00:02Z");
+        orchestrationDecision1.setNextAction("Continue");
+        orchestrationDecision1.setAppReference("UNIT_TEST");
+        orchestrationDecision1.setDecisionReasons(List.of("Test"));
+
+        orchestrationDecisions.add(orchestrationDecision1);
+        payload.setOrchestrationDecisions(orchestrationDecisions);
+
+        List<DecisionElement> decisionElements = new ArrayList<>();
+        DecisionElement decisionElement1 = new DecisionElement();
+        decisionElement1.setApplicantId("APPLICANT_1");
+        decisionElement1.setServiceName("Authenticateplus");
+        decisionElement1.setDecision("AU01");
+        decisionElement1.setScore(90);
+        decisionElement1.setDecisionText("OK");
+        decisionElement1.setDecisionReason("TEST");
+        decisionElement1.setAppReference("UNIT_TEST");
+
+        List<Rule> rules = new ArrayList<>();
+        Rule rule1 = new Rule();
+        rule1.setRuleName("AUTP_IDCONFLEVEL");
+        rule1.setRuleId("");
+        rule1.setRuleScore(1);
+        rule1.setRuleText("Conf Level 1");
+
+        rules.add(rule1);
+        decisionElement1.setRules(rules);
+
+        decisionElements.add(decisionElement1);
+        payload.setDecisionElements(decisionElements);
+
+        testIVR.setClientResponsePayload(payload);
+
+        return testIVR;
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

S1 & S2 - Prior to response validation the request status code is inspected with OK being forwarded.

S3 & S4 - After an OK status, info responses are validated, with any validation errors collected.

Info Response -
After receiving an INFO response the data is validated with IdentityVerificationInfoResponseValidator.
Validator includes a matching set of unit tests.
Removed all null checks post validation as the validator now includes this.
Rules field validation is not strict, this could be improved with informing the validator which services rules are expected from.

Post validation processing will inspect all decision elements present for rules.
The absence of a rules node will fail validation, but presence of an empty one will not.

### Why did it change

To match scenarios requested in [KBV-499]

### Issue tracking

- [KBV-499](https://govukverify.atlassian.net/browse/KBV-499)


[KBV-499]: https://govukverify.atlassian.net/browse/KBV-499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ