### PR TITLE
KBV-499 Improve Unit Test Coverage and Fix logging mapped fraud codes as unmapped.

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ContraIndicatorRemoteMapper.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ContraIndicatorRemoteMapper.java
@@ -59,7 +59,7 @@ public class ContraIndicatorRemoteMapper implements ContraindicationMapper {
         if (contraindicators.size() != thirdPartyFraudCodes.length) {
             String[] unmappedFraudCodes =
                     Arrays.stream(thirdPartyFraudCodes)
-                            .filter(fraudCode -> !contraindicators.contains(fraudCode))
+                            .filter(fraudCode -> !uCodeCIMap.containsKey(fraudCode))
                             .toArray(String[]::new);
 
             String unmappedFraudCodesAsString = String.join(", ", unmappedFraudCodes);

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidator.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidator.java
@@ -49,6 +49,11 @@ public class IdentityVerificationInfoResponseValidator {
 
     public static final String NULL_RESPONSE_ERROR_MESSAGE = "Response is null";
     public static final String NULL_HEADER_ERROR_MESSAGE = "Header not found.";
+
+    public static final String NULL_ORCHESTRATION_DECISION_ERROR_MESSAGE =
+            "Orchestration Decision is null.";
+    public static final String NULL_DECISION_ELEMENT_ERROR_MESSAGE = "Decision Element is null.";
+
     public static final String NULL_HEADER_OVERALL_RESPONSE_ERROR_MESSAGE =
             "Header Overall response not found.";
     public static final String RESPONSE_TYPE_ERROR_MESSAGE =
@@ -222,7 +227,7 @@ public class IdentityVerificationInfoResponseValidator {
     private void validateIdentityVerificationResponseClientResponsePayloadOrchestrationDecision(
             OrchestrationDecision orchestrationDecision, List<String> validationErrors) {
         if (orchestrationDecision == null) {
-            validationErrors.add("OrchestrationDecision is null");
+            validationErrors.add(NULL_ORCHESTRATION_DECISION_ERROR_MESSAGE);
             return;
         }
 
@@ -293,7 +298,7 @@ public class IdentityVerificationInfoResponseValidator {
     private void validateIdentityVerificationResponseClientResponsePayloadDecisionElement(
             DecisionElement decisionElement, final List<String> validationErrors) {
         if (decisionElement == null) {
-            validationErrors.add("DecisionElement is null");
+            validationErrors.add(NULL_DECISION_ELEMENT_ERROR_MESSAGE);
             return;
         }
 

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
@@ -60,6 +60,12 @@ public class IdentityVerificationService {
                     result.setContraIndicators(contraindications);
                     result.setIdentityCheckScore(identityCheckScore);
                     result.setTransactionId(fraudCheckResult.getTransactionId());
+                } else {
+                    if (null != fraudCheckResult.getErrorMessage()) {
+                        result.setError(fraudCheckResult.getErrorMessage());
+                    } else {
+                        result.setError("Unknown error returned from supplier");
+                    }
                 }
                 return result;
             }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
@@ -1046,6 +1046,22 @@ public class IdentityVerificationInfoResponseValidatorTest {
     }
 
     @Test
+    void clientPayloadOrchestrationDecisionsCannotHaveANullElement() {
+        testIVResponse.getClientResponsePayload().getOrchestrationDecisions().set(0, null);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                IdentityVerificationInfoResponseValidator.NULL_ORCHESTRATION_DECISION_ERROR_MESSAGE;
+
+        assertNull(testIVResponse.getClientResponsePayload().getOrchestrationDecisions().get(0));
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
     void clientPayloadOrchestrationDecisionsOrchestrationDecisionSequenceIdCannotBeEmpty() {
         final String TEST_STRING = "";
         testIVResponse
@@ -1905,6 +1921,22 @@ public class IdentityVerificationInfoResponseValidatorTest {
                 "DecisionElements" + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
 
         assertEquals(0, testIVResponse.getClientResponsePayload().getDecisionElements().size());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void clientPayloadDecisionElementsCannotHaveANullElement() {
+        testIVResponse.getClientResponsePayload().getDecisionElements().set(0, null);
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        final String EXPECTED_ERROR =
+                IdentityVerificationInfoResponseValidator.NULL_DECISION_ELEMENT_ERROR_MESSAGE;
+
+        assertNull(testIVResponse.getClientResponsePayload().getDecisionElements().get(0));
         assertEquals(1, validationResult.getError().size());
         assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
         assertFalse(validationResult.isValid());

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/JsonValidationUtilityTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/JsonValidationUtilityTest.java
@@ -1,0 +1,473 @@
+package uk.gov.di.ipv.cri.fraud.api.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JsonValidationUtilityTest {
+
+    private static List<String> TEST_LIST;
+    private static String TEST_STRING;
+    private static int TEST_INT;
+    private static final int TEST_INT_RANGE_MIN = 0;
+    private static final int TEST_INT_RANGE_MAX = 127;
+    private static List<String> validationErrors;
+
+    private static final String TEST_LIST_NAME = "TestList";
+    private static final String TEST_STRING_NAME = "TestString";
+    private static final String TEST_INTEGER_NAME = "TestInteger";
+
+    @BeforeEach
+    public void PreEachTestSetup() {
+        TEST_LIST = new ArrayList<>();
+        TEST_STRING = "";
+        TEST_INT = 0;
+        validationErrors = new ArrayList<>();
+    }
+
+    @Test
+    void staticJsonValidationUtilityClassIsFinal() {
+        boolean finalClass = Modifier.isFinal(JsonValidationUtility.class.getModifiers());
+        assertTrue(finalClass);
+    }
+
+    @Test
+    void staticJsonValidationUtilityClassCannotBeInstantiated() throws NoSuchMethodException {
+
+        Constructor constructor = JsonValidationUtility.class.getDeclaredConstructor();
+
+        constructor.setAccessible(true);
+        assertThrows(InvocationTargetException.class, () -> constructor.newInstance());
+
+        boolean privateConstructor = Modifier.isPrivate(constructor.getModifiers());
+
+        assertTrue(privateConstructor);
+    }
+
+    @Test
+    void validateListDataEmptyIsAllowed_PassesWithEmptyList() {
+        boolean result =
+                JsonValidationUtility.validateListDataEmptyIsAllowed(
+                        TEST_LIST, TEST_LIST_NAME, validationErrors);
+
+        assertEquals(0, TEST_LIST.size());
+        assertEquals(0, validationErrors.size());
+        assertTrue(result);
+    }
+
+    @Test
+    void validateListDataEmptyIsAllowed_PassesWithFilledList() {
+        TEST_STRING = "Test";
+        TEST_LIST.add(TEST_STRING);
+
+        boolean result =
+                JsonValidationUtility.validateListDataEmptyIsAllowed(
+                        TEST_LIST, TEST_LIST_NAME, validationErrors);
+
+        assertEquals(1, TEST_LIST.size());
+        assertEquals(TEST_STRING, TEST_LIST.get(0));
+        assertEquals(0, validationErrors.size());
+        assertTrue(result);
+    }
+
+    @Test
+    void validateListDataEmptyIsAllowed_FailsWithNullList() {
+        TEST_LIST = null;
+
+        final String EXPECTED_ERROR =
+                TEST_LIST_NAME + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+
+        boolean result =
+                JsonValidationUtility.validateListDataEmptyIsAllowed(
+                        TEST_LIST, TEST_LIST_NAME, validationErrors);
+
+        assertEquals(1, validationErrors.size());
+        assertEquals(EXPECTED_ERROR, validationErrors.get(0));
+        assertFalse(result);
+    }
+
+    @Test
+    void validateListDataEmptyIsFail_PassesWithFilledList() {
+        TEST_STRING = "Test";
+        TEST_LIST.add(TEST_STRING);
+
+        boolean result =
+                JsonValidationUtility.validateListDataEmptyIsFail(
+                        TEST_LIST, TEST_LIST_NAME, validationErrors);
+
+        assertEquals(1, TEST_LIST.size());
+        assertEquals(TEST_STRING, TEST_LIST.get(0));
+        assertEquals(0, validationErrors.size());
+        assertTrue(result);
+    }
+
+    @Test
+    void validateListDataEmptyIsFail_FailsWithNullList() {
+        TEST_LIST = null;
+
+        final String EXPECTED_ERROR =
+                TEST_LIST_NAME + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+
+        boolean result =
+                JsonValidationUtility.validateListDataEmptyIsFail(
+                        TEST_LIST, TEST_LIST_NAME, validationErrors);
+
+        assertEquals(1, validationErrors.size());
+        assertEquals(EXPECTED_ERROR, validationErrors.get(0));
+        assertFalse(result);
+    }
+
+    @Test
+    void validateListDataEmptyIsFail_FailsWithEmptyList() {
+        TEST_LIST = new ArrayList<>();
+
+        final String EXPECTED_ERROR =
+                TEST_LIST_NAME + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        boolean result =
+                JsonValidationUtility.validateListDataEmptyIsFail(
+                        TEST_LIST, TEST_LIST_NAME, validationErrors);
+
+        assertEquals(1, validationErrors.size());
+        assertEquals(EXPECTED_ERROR, validationErrors.get(0));
+        assertFalse(result);
+    }
+
+    @Test
+    void validateStringDataEmptyIsFail_PassesWithFilledString() {
+        TEST_STRING = "Test";
+        final int TEST_LENGTH = TEST_STRING.length();
+
+        boolean result =
+                JsonValidationUtility.validateStringDataEmptyIsFail(
+                        TEST_STRING, TEST_LENGTH, TEST_STRING_NAME, validationErrors);
+
+        assertEquals(0, validationErrors.size());
+        assertTrue(result);
+    }
+
+    @Test
+    void validateStringDataEmptyIsFail_FailsWithEmptyString() {
+        TEST_STRING = "";
+        final int TEST_LENGTH = Integer.MAX_VALUE;
+
+        final String EXPECTED_ERROR =
+                TEST_STRING_NAME + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        boolean result =
+                JsonValidationUtility.validateStringDataEmptyIsFail(
+                        TEST_STRING, TEST_LENGTH, TEST_STRING_NAME, validationErrors);
+
+        assertEquals(1, validationErrors.size());
+        assertEquals(EXPECTED_ERROR, validationErrors.get(0));
+        assertFalse(result);
+    }
+
+    @Test
+    void validateStringDataEmptyIsFail_FailsWithNullString() {
+        TEST_STRING = null;
+        final int TEST_LENGTH = Integer.MAX_VALUE;
+
+        final String EXPECTED_ERROR =
+                TEST_STRING_NAME + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+
+        boolean result =
+                JsonValidationUtility.validateStringDataEmptyIsFail(
+                        TEST_STRING, TEST_LENGTH, TEST_STRING_NAME, validationErrors);
+
+        assertEquals(1, validationErrors.size());
+        assertEquals(EXPECTED_ERROR, validationErrors.get(0));
+        assertFalse(result);
+    }
+
+    @Test
+    void validateStringDataEmptyIsFail_FailsWithTooLongString() {
+
+        TEST_STRING = "Test";
+        final int TEST_LENGTH = TEST_STRING.length() - 1;
+
+        final String EXPECTED_ERROR =
+                TEST_STRING_NAME + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        boolean result =
+                JsonValidationUtility.validateStringDataEmptyIsFail(
+                        TEST_STRING, TEST_LENGTH, TEST_STRING_NAME, validationErrors);
+
+        assertEquals(1, validationErrors.size());
+        assertEquals(EXPECTED_ERROR, validationErrors.get(0));
+        assertFalse(result);
+    }
+
+    @Test
+    void validateStringDataEmptyIsAllowed_PassesWithFilledString() {
+        TEST_STRING = "Test";
+        final int TEST_LENGTH = TEST_STRING.length();
+
+        boolean result =
+                JsonValidationUtility.validateStringDataEmptyIsAllowed(
+                        TEST_STRING, TEST_LENGTH, TEST_STRING_NAME, validationErrors);
+
+        assertEquals(0, validationErrors.size());
+        assertTrue(result);
+    }
+
+    @Test
+    void validateStringDataEmptyIsAllowed_PassesWithEmptyString() {
+        TEST_STRING = "";
+        final int TEST_LENGTH = TEST_STRING.length();
+
+        boolean result =
+                JsonValidationUtility.validateStringDataEmptyIsAllowed(
+                        TEST_STRING, TEST_LENGTH, TEST_STRING_NAME, validationErrors);
+
+        assertEquals(0, validationErrors.size());
+        assertTrue(result);
+    }
+
+    @Test
+    void validateStringDataEmptyIsAllowed_FailsWithNullString() {
+        TEST_STRING = null;
+        final int TEST_LENGTH = Integer.MAX_VALUE;
+
+        final String EXPECTED_ERROR =
+                TEST_STRING_NAME + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+
+        boolean result =
+                JsonValidationUtility.validateStringDataEmptyIsAllowed(
+                        TEST_STRING, TEST_LENGTH, TEST_STRING_NAME, validationErrors);
+
+        assertEquals(1, validationErrors.size());
+        assertEquals(EXPECTED_ERROR, validationErrors.get(0));
+        assertFalse(result);
+    }
+
+    @Test
+    void validateStringDataEmptyIsAllowed_FailsWithTooLongString() {
+        TEST_STRING = "Test";
+        final int TEST_LENGTH = TEST_STRING.length() - 1;
+
+        final String EXPECTED_ERROR =
+                TEST_STRING_NAME + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        boolean result =
+                JsonValidationUtility.validateStringDataEmptyIsAllowed(
+                        TEST_STRING, TEST_LENGTH, TEST_STRING_NAME, validationErrors);
+
+        assertEquals(1, validationErrors.size());
+        assertEquals(EXPECTED_ERROR, validationErrors.get(0));
+        assertFalse(result);
+    }
+
+    @Test
+    void validateStringDataNullAndEmptyIsAllowedPassesWithFilledString() {
+        TEST_STRING = "Test";
+        final int TEST_LENGTH = TEST_STRING.length();
+
+        boolean result =
+                JsonValidationUtility.validateStringDataNullAndEmptyIsAllowed(
+                        TEST_STRING, TEST_LENGTH, TEST_STRING_NAME, validationErrors);
+
+        assertEquals(0, validationErrors.size());
+        assertTrue(result);
+    }
+
+    @Test
+    void validateStringDataNullAndEmptyIsAllowed_PassesWithEmptyString() {
+        TEST_STRING = "";
+        final int TEST_LENGTH = TEST_STRING.length();
+
+        boolean result =
+                JsonValidationUtility.validateStringDataNullAndEmptyIsAllowed(
+                        TEST_STRING, TEST_LENGTH, TEST_STRING_NAME, validationErrors);
+
+        assertEquals(0, validationErrors.size());
+        assertTrue(result);
+    }
+
+    @Test
+    void validateStringDataNullAndEmptyIsAllowed_PassesWithNullString() {
+        TEST_STRING = null;
+        final int TEST_LENGTH = Integer.MAX_VALUE;
+
+        boolean result =
+                JsonValidationUtility.validateStringDataNullAndEmptyIsAllowed(
+                        TEST_STRING, TEST_LENGTH, TEST_STRING_NAME, validationErrors);
+
+        assertEquals(0, validationErrors.size());
+        assertTrue(result);
+    }
+
+    @Test
+    void validateStringDataNullAndEmptyIsAllowed_FailsWithTooLongString() {
+        TEST_STRING = "Test";
+        final int TEST_LENGTH = TEST_STRING.length() - 1;
+
+        final String EXPECTED_ERROR =
+                TEST_STRING_NAME + JsonValidationUtility.IS_TOO_LONG_ERROR_MESSAGE_SUFFIX;
+
+        boolean result =
+                JsonValidationUtility.validateStringDataNullAndEmptyIsAllowed(
+                        TEST_STRING, TEST_LENGTH, TEST_STRING_NAME, validationErrors);
+
+        assertEquals(1, validationErrors.size());
+        assertEquals(EXPECTED_ERROR, validationErrors.get(0));
+        assertFalse(result);
+    }
+
+    @Test
+    void validateTimeStampData_PassesWithValidTimeStamp() {
+        TEST_STRING = "2022-01-01T00:00:01Z";
+
+        boolean result =
+                JsonValidationUtility.validateTimeStampData(
+                        TEST_STRING, TEST_STRING_NAME, validationErrors);
+
+        assertEquals(0, validationErrors.size());
+        assertTrue(result);
+    }
+
+    @Test
+    void validateTimeStampData_FailsWithNullString() {
+        TEST_STRING = null;
+
+        boolean result =
+                JsonValidationUtility.validateTimeStampData(
+                        TEST_STRING, TEST_STRING_NAME, validationErrors);
+
+        final String EXPECTED_ERROR =
+                TEST_STRING_NAME + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(1, validationErrors.size());
+        assertEquals(EXPECTED_ERROR, validationErrors.get(0));
+        assertFalse(result);
+    }
+
+    @Test
+    void validateTimeStampData_FailsWithEmptyString() {
+        TEST_STRING = "";
+
+        boolean result =
+                JsonValidationUtility.validateTimeStampData(
+                        TEST_STRING, TEST_STRING_NAME, validationErrors);
+
+        final String EXPECTED_ERROR =
+                TEST_STRING_NAME + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(1, validationErrors.size());
+        assertEquals(EXPECTED_ERROR, validationErrors.get(0));
+        assertFalse(result);
+    }
+
+    @Test
+    void validateTimeStampData_FailsWithInvalidTimeStamp() {
+        TEST_STRING = "123";
+
+        boolean result =
+                JsonValidationUtility.validateTimeStampData(
+                        TEST_STRING, TEST_STRING_NAME, validationErrors);
+
+        final String EXPECTED_ERROR =
+                TEST_STRING_NAME
+                        + JsonValidationUtility.FAIL_PARSING_TIMESTAMP_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(1, validationErrors.size());
+        assertEquals(EXPECTED_ERROR, validationErrors.get(0));
+        assertFalse(result);
+    }
+
+    @Test
+    void validateIntegerRangeData_PassesWithinRange() {
+        TEST_INT = 63;
+
+        boolean result =
+                JsonValidationUtility.validateIntegerRangeData(
+                        TEST_INT,
+                        TEST_INT_RANGE_MIN,
+                        TEST_INT_RANGE_MAX,
+                        "TEST_INTEGER_NAME",
+                        validationErrors);
+
+        assertEquals(0, validationErrors.size());
+        assertTrue(result);
+    }
+
+    @Test
+    void validateIntegerRangeData_PassesAtMinRange() {
+        TEST_INT = TEST_INT_RANGE_MIN;
+
+        boolean result =
+                JsonValidationUtility.validateIntegerRangeData(
+                        TEST_INT,
+                        TEST_INT_RANGE_MIN,
+                        TEST_INT_RANGE_MAX,
+                        "TEST_INTEGER_NAME",
+                        validationErrors);
+
+        assertEquals(0, validationErrors.size());
+        assertTrue(result);
+    }
+
+    @Test
+    void validateIntegerRangeData_PassesAtMaxRange() {
+        TEST_INT = TEST_INT_RANGE_MAX;
+
+        boolean result =
+                JsonValidationUtility.validateIntegerRangeData(
+                        TEST_INT,
+                        TEST_INT_RANGE_MIN,
+                        TEST_INT_RANGE_MAX,
+                        "TEST_INTEGER_NAME",
+                        validationErrors);
+
+        assertEquals(0, validationErrors.size());
+        assertTrue(result);
+    }
+
+    @Test
+    void validateIntegerRangeData_FailsUnderMinRange() {
+        TEST_INT = TEST_INT_RANGE_MIN - 1;
+
+        boolean result =
+                JsonValidationUtility.validateIntegerRangeData(
+                        TEST_INT,
+                        TEST_INT_RANGE_MIN,
+                        TEST_INT_RANGE_MAX,
+                        TEST_INTEGER_NAME,
+                        validationErrors);
+
+        final String EXPECTED_ERROR =
+                TEST_INTEGER_NAME + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(1, validationErrors.size());
+        assertEquals(EXPECTED_ERROR, validationErrors.get(0));
+        assertFalse(result);
+    }
+
+    @Test
+    void validateIntegerRangeData_FailsOverMaxRange() {
+        TEST_INT = TEST_INT_RANGE_MAX + 1;
+
+        boolean result =
+                JsonValidationUtility.validateIntegerRangeData(
+                        TEST_INT,
+                        TEST_INT_RANGE_MIN,
+                        TEST_INT_RANGE_MAX,
+                        TEST_INTEGER_NAME,
+                        validationErrors);
+
+        final String EXPECTED_ERROR =
+                TEST_INTEGER_NAME + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+
+        assertEquals(1, validationErrors.size());
+        assertEquals(EXPECTED_ERROR, validationErrors.get(0));
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
### What changed

Fix logging mapped fraud codes as unmapped.
UnitTest coverage added to JsonValidationUtility.
Coverage Improved in IdentityVerificationInfoResponseValidator.
Fix a null pointer in IdentityVerificationService when fraud check fails due to an error response type.

### Why did it change

Unmapped Fraud Codes where being logged with all log codes, only unmapped codes are now error logged.

JsonValidationUtility - These methods where develop as internal to the IdentityVerificationInfoResponseValidator but have been split out to be reused. The intended standalone functioning is now tested in these unit test.

IdentityVerificationInfoResponseValidator, code paths not covered by unit test are now covered.

### Issue tracking

[KBV-499](https://govukverify.atlassian.net/browse/KBV-499)