### PR TITLE
KBV-567 Policy to read the verifiable-credential/issuer SSM param

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -252,6 +252,7 @@ Resources:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/FraudCriAudience"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AuthRequestKmsEncryptionKeyId"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/PersonIdentityTableName"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiable-credential/issuer"
         - Statement:
             - Effect: Allow
               Action:
@@ -310,6 +311,8 @@ Resources:
               Action:
                 - 'ssm:GetParameter*'
               Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Environment}/credentialIssuers/fraud*'
+        - SSMParameterReadPolicy:
+            ParameterName: !Sub "${AWS::StackName}/verifiable-credential/issuer"
         - Statement:
             - Sid: ReadSecretsPolicy
               Effect: Allow


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

A merged `cri-lib` PR allows us to send the CRI issuer uri to TxMA, see https://github.com/alphagov/di-ipv-cri-lib/pull/29

This PR adds a policy to allow a read of the issuer from an existing SSM param. The policy is required by lambdas using the `AuditService` to send events to TxMA.

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-567](https://govukverify.atlassian.net/browse/KBV-567)
