### PR TITLE
KBV-590 - Improve unit test coverage in error pathways.

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGateway.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGateway.java
@@ -27,6 +27,16 @@ public class ThirdPartyFraudGateway {
     private final HmacGenerator hmacGenerator;
     private final URI endpointUri;
 
+    public static final String HTTP_300_REDIRECT_MESSAGE =
+            "Redirection Message returned from Fraud Check Response, Status Code - ";
+    public static final String HTTP_400_CLIENT_REQUEST_ERROR =
+            "Client Request Error returned from Fraud Check Response, Status Code - ";
+    public static final String HTTP_500_SERVER_ERROR =
+            "Server Error returned from Fraud Check Response, Status Code - ";
+
+    public static final String HTTP_UNHANDLED_ERROR =
+            "Unhandled HTTP Response from Fraud Check Response, Status Code - ";
+
     public ThirdPartyFraudGateway(
             HttpClient httpClient,
             IdentityVerificationRequestMapper requestMapper,
@@ -85,17 +95,13 @@ public class ThirdPartyFraudGateway {
             fraudCheckResult.setExecutedSuccessfully(false);
 
             if (statusCode >= 300 && statusCode <= 399) {
-                fraudCheckResult.setErrorMessage(
-                        "Redirection Message returned from Fraud Check Response " + statusCode);
+                fraudCheckResult.setErrorMessage(HTTP_300_REDIRECT_MESSAGE + statusCode);
             } else if (statusCode >= 400 && statusCode <= 499) {
-                fraudCheckResult.setErrorMessage(
-                        "Client Request Error returned from Fraud Check Response " + statusCode);
+                fraudCheckResult.setErrorMessage(HTTP_400_CLIENT_REQUEST_ERROR + statusCode);
             } else if (statusCode >= 500 && statusCode <= 599) {
-                fraudCheckResult.setErrorMessage(
-                        "Server Error returned from Fraud Check Response " + statusCode);
+                fraudCheckResult.setErrorMessage(HTTP_500_SERVER_ERROR + statusCode);
             } else {
-                fraudCheckResult.setErrorMessage(
-                        "Unhandled Fraud Check HTTP Response " + statusCode);
+                fraudCheckResult.setErrorMessage(HTTP_UNHANDLED_ERROR + statusCode);
             }
 
             return fraudCheckResult;

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
@@ -17,6 +17,11 @@ public class IdentityVerificationService {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String ERROR_MSG_CONTEXT =
             "Error occurred when attempting to invoke the third party api";
+
+    private static final String ERROR_FRAUD_CHECK_RESULT_RETURN_NULL =
+            "Null FraudCheckResult returned when invoking third party API.";
+    private static final String ERROR_FRAUD_CHECK_RESULT_NO_ERR_MSG =
+            "FraudCheckResult had no error message.";
     private final ThirdPartyFraudGateway thirdPartyGateway;
     private final PersonIdentityValidator personIdentityValidator;
     private final ContraindicationMapper contraindicationMapper;
@@ -76,16 +81,17 @@ public class IdentityVerificationService {
                             identityCheckScore);
                 } else {
                     LOGGER.warn("Fraud check failed");
-                    if (null != fraudCheckResult.getErrorMessage()) {
+                    if (Objects.nonNull(fraudCheckResult.getErrorMessage())) {
                         result.setError(fraudCheckResult.getErrorMessage());
                     } else {
-                        result.setError("Unknown error returned from supplier");
+                        result.setError(ERROR_FRAUD_CHECK_RESULT_NO_ERR_MSG);
+                        LOGGER.warn(ERROR_FRAUD_CHECK_RESULT_NO_ERR_MSG);
                     }
                 }
                 return result;
             }
 
-            LOGGER.error("Unexpected null returned when invoking third party API");
+            LOGGER.error(ERROR_FRAUD_CHECK_RESULT_RETURN_NULL);
             result.setError(ERROR_MSG_CONTEXT);
             result.setSuccess(false);
         } catch (InterruptedException ie) {

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationResponseMapperTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationResponseMapperTest.java
@@ -3,11 +3,7 @@ package uk.gov.di.ipv.cri.fraud.api.gateway;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.cri.fraud.api.domain.FraudCheckResult;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.DecisionElement;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.IdentityVerificationResponse;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.ResponseHeader;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.ResponseType;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.Rule;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.*;
 import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
 
 import java.util.List;
@@ -27,33 +23,9 @@ class IdentityVerificationResponseMapperTest {
     }
 
     @Test
-    void mapIdentityVerificationResponseShouldMapWarnErrorResponse() {
-        String responseCode = "response-code";
-        String responseMessage = "response-message";
-        IdentityVerificationResponse testIdentityVerificationResponse =
-                new IdentityVerificationResponse();
-        ResponseHeader responseHeader = new ResponseHeader();
-        responseHeader.setResponseType(ResponseType.ERROR);
-        responseHeader.setResponseCode(responseCode);
-        responseHeader.setResponseMessage(responseMessage);
-        testIdentityVerificationResponse.setResponseHeader(responseHeader);
-
-        FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(
-                        testIdentityVerificationResponse);
-
-        assertNotNull(fraudCheckResult);
-        assertFalse(fraudCheckResult.isExecutedSuccessfully());
-        assertEquals(
-                "Error code: " + responseCode + ", error description: " + responseMessage,
-                fraudCheckResult.getErrorMessage());
-        assertEquals(0, fraudCheckResult.getThirdPartyFraudCodes().length);
-    }
-
-    @Test
     void mapIdentityVerificationResponseShouldMapInfoResponse() {
         IdentityVerificationResponse testIdentityVerificationResponse =
-                TestDataCreator.createTestVerificationInfoResponse();
+                TestDataCreator.createTestVerificationResponse(ResponseType.INFO);
 
         DecisionElement decisionElement =
                 testIdentityVerificationResponse
@@ -76,5 +48,310 @@ class IdentityVerificationResponseMapperTest {
         assertNull(fraudCheckResult.getErrorMessage());
         assertEquals(1, fraudCheckResult.getThirdPartyFraudCodes().length);
         assertEquals(rule.getRuleId(), fraudCheckResult.getThirdPartyFraudCodes()[0]);
+    }
+
+    @Test
+    void mapIdentityVerificationInfoResponsesThatFailReturnFail() {
+        IdentityVerificationResponse testIdentityVerificationResponse =
+                TestDataCreator.createTestVerificationResponse(ResponseType.INFO);
+
+        testIdentityVerificationResponse.getResponseHeader().setTenantID(null);
+
+        FraudCheckResult fraudCheckResult =
+                this.responseMapper.mapIdentityVerificationResponse(
+                        testIdentityVerificationResponse);
+
+        final String EXPECTED_ERROR =
+                IdentityVerificationResponseMapper.IV_INFO_RESPONSE_VALIDATION_FAILED_MSG;
+
+        assertNotNull(fraudCheckResult);
+        assertFalse(fraudCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
+    }
+
+    @Test
+    void mapIdentityVerificationResponseShouldMapWarnResponse() {
+        String responseCode = "response-code";
+        String responseMessage = "response-message";
+        final ResponseType TYPE = ResponseType.WARN;
+
+        IdentityVerificationResponse testIdentityVerificationResponse =
+                TestDataCreator.createTestVerificationResponse(TYPE);
+
+        ResponseHeader responseHeader = testIdentityVerificationResponse.getResponseHeader();
+        responseHeader.setResponseCode(responseCode);
+        responseHeader.setResponseMessage(responseMessage);
+
+        testIdentityVerificationResponse.setResponseHeader(responseHeader);
+
+        FraudCheckResult fraudCheckResult =
+                this.responseMapper.mapIdentityVerificationResponse(
+                        testIdentityVerificationResponse);
+
+        assertEquals(responseHeader, testIdentityVerificationResponse.getResponseHeader());
+        assertEquals(TYPE, testIdentityVerificationResponse.getResponseHeader().getResponseType());
+        assertEquals(
+                responseCode,
+                testIdentityVerificationResponse.getResponseHeader().getResponseCode());
+        assertEquals(
+                responseMessage,
+                testIdentityVerificationResponse.getResponseHeader().getResponseMessage());
+
+        final String EXPECTED_ERROR =
+                String.format(
+                        IdentityVerificationResponseMapper.IV_ERROR_RESPONSE_ERROR_MESSAGE_FORMAT,
+                        responseCode,
+                        responseMessage);
+
+        assertNotNull(fraudCheckResult);
+        assertFalse(fraudCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
+        assertEquals(0, fraudCheckResult.getThirdPartyFraudCodes().length);
+    }
+
+    @Test
+    void mapIdentityVerificationResponseShouldMapWarningResponse() {
+        String responseCode = "response-code";
+        String responseMessage = "response-message";
+        final ResponseType TYPE = ResponseType.WARNING;
+
+        IdentityVerificationResponse testIdentityVerificationResponse =
+                TestDataCreator.createTestVerificationResponse(TYPE);
+
+        ResponseHeader responseHeader = testIdentityVerificationResponse.getResponseHeader();
+        responseHeader.setResponseCode(responseCode);
+        responseHeader.setResponseMessage(responseMessage);
+
+        testIdentityVerificationResponse.setResponseHeader(responseHeader);
+
+        FraudCheckResult fraudCheckResult =
+                this.responseMapper.mapIdentityVerificationResponse(
+                        testIdentityVerificationResponse);
+
+        assertEquals(responseHeader, testIdentityVerificationResponse.getResponseHeader());
+        assertEquals(TYPE, testIdentityVerificationResponse.getResponseHeader().getResponseType());
+        assertEquals(
+                responseCode,
+                testIdentityVerificationResponse.getResponseHeader().getResponseCode());
+        assertEquals(
+                responseMessage,
+                testIdentityVerificationResponse.getResponseHeader().getResponseMessage());
+
+        final String EXPECTED_ERROR =
+                String.format(
+                        IdentityVerificationResponseMapper.IV_ERROR_RESPONSE_ERROR_MESSAGE_FORMAT,
+                        responseCode,
+                        responseMessage);
+
+        assertNotNull(fraudCheckResult);
+        assertFalse(fraudCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
+        assertEquals(0, fraudCheckResult.getThirdPartyFraudCodes().length);
+    }
+
+    @Test
+    void mapIdentityVerificationResponseShouldMapErrorResponse() {
+        String responseCode = "response-code";
+        String responseMessage = "response-message";
+        final ResponseType TYPE = ResponseType.ERROR;
+
+        IdentityVerificationResponse testIdentityVerificationResponse =
+                TestDataCreator.createTestVerificationResponse(TYPE);
+
+        ResponseHeader responseHeader = testIdentityVerificationResponse.getResponseHeader();
+        responseHeader.setResponseCode(responseCode);
+        responseHeader.setResponseMessage(responseMessage);
+
+        testIdentityVerificationResponse.setResponseHeader(responseHeader);
+
+        FraudCheckResult fraudCheckResult =
+                this.responseMapper.mapIdentityVerificationResponse(
+                        testIdentityVerificationResponse);
+
+        assertEquals(responseHeader, testIdentityVerificationResponse.getResponseHeader());
+        assertEquals(TYPE, testIdentityVerificationResponse.getResponseHeader().getResponseType());
+        assertEquals(
+                responseCode,
+                testIdentityVerificationResponse.getResponseHeader().getResponseCode());
+        assertEquals(
+                responseMessage,
+                testIdentityVerificationResponse.getResponseHeader().getResponseMessage());
+
+        final String EXPECTED_ERROR =
+                String.format(
+                        IdentityVerificationResponseMapper.IV_ERROR_RESPONSE_ERROR_MESSAGE_FORMAT,
+                        responseCode,
+                        responseMessage);
+
+        assertNotNull(fraudCheckResult);
+        assertFalse(fraudCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
+        assertEquals(0, fraudCheckResult.getThirdPartyFraudCodes().length);
+    }
+
+    @Test
+    void mapIdentityVerificationResponseFraudCheckErrorMessageCannotBeNullWithNullResponseCode() {
+        String responseCode = null;
+        String responseMessage = "response-message";
+        final ResponseType TYPE = ResponseType.ERROR;
+
+        IdentityVerificationResponse testIdentityVerificationResponse =
+                TestDataCreator.createTestVerificationResponse(TYPE);
+
+        ResponseHeader responseHeader = testIdentityVerificationResponse.getResponseHeader();
+        responseHeader.setResponseCode(responseCode);
+        responseHeader.setResponseMessage(responseMessage);
+
+        testIdentityVerificationResponse.setResponseHeader(responseHeader);
+
+        FraudCheckResult fraudCheckResult =
+                this.responseMapper.mapIdentityVerificationResponse(
+                        testIdentityVerificationResponse);
+
+        assertEquals(responseHeader, testIdentityVerificationResponse.getResponseHeader());
+        assertEquals(TYPE, testIdentityVerificationResponse.getResponseHeader().getResponseType());
+        assertEquals(
+                responseCode,
+                testIdentityVerificationResponse.getResponseHeader().getResponseCode());
+        assertEquals(
+                responseMessage,
+                testIdentityVerificationResponse.getResponseHeader().getResponseMessage());
+
+        final String EXPECTED_ERROR =
+                String.format(
+                        IdentityVerificationResponseMapper.IV_ERROR_RESPONSE_ERROR_MESSAGE_FORMAT,
+                        IdentityVerificationResponseMapper
+                                .IV_ERROR_RESPONSE_ERROR_MESSAGE_DEFAULT_FIELD_VALUE_IF_BLANK,
+                        responseMessage);
+
+        assertNotNull(fraudCheckResult);
+        assertFalse(fraudCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
+        assertEquals(0, fraudCheckResult.getThirdPartyFraudCodes().length);
+    }
+
+    @Test
+    void mapIdentityVerificationResponseFraudCheckErrorMessageCannotBeEmptyWithEmptyResponseCode() {
+        String responseCode = "";
+        String responseMessage = "response-message";
+        final ResponseType TYPE = ResponseType.ERROR;
+
+        IdentityVerificationResponse testIdentityVerificationResponse =
+                TestDataCreator.createTestVerificationResponse(TYPE);
+
+        ResponseHeader responseHeader = testIdentityVerificationResponse.getResponseHeader();
+        responseHeader.setResponseCode(responseCode);
+        responseHeader.setResponseMessage(responseMessage);
+
+        testIdentityVerificationResponse.setResponseHeader(responseHeader);
+
+        FraudCheckResult fraudCheckResult =
+                this.responseMapper.mapIdentityVerificationResponse(
+                        testIdentityVerificationResponse);
+
+        assertEquals(responseHeader, testIdentityVerificationResponse.getResponseHeader());
+        assertEquals(TYPE, testIdentityVerificationResponse.getResponseHeader().getResponseType());
+        assertEquals(
+                responseCode,
+                testIdentityVerificationResponse.getResponseHeader().getResponseCode());
+        assertEquals(
+                responseMessage,
+                testIdentityVerificationResponse.getResponseHeader().getResponseMessage());
+
+        final String EXPECTED_ERROR =
+                String.format(
+                        IdentityVerificationResponseMapper.IV_ERROR_RESPONSE_ERROR_MESSAGE_FORMAT,
+                        IdentityVerificationResponseMapper
+                                .IV_ERROR_RESPONSE_ERROR_MESSAGE_DEFAULT_FIELD_VALUE_IF_BLANK,
+                        responseMessage);
+
+        assertNotNull(fraudCheckResult);
+        assertFalse(fraudCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
+        assertEquals(0, fraudCheckResult.getThirdPartyFraudCodes().length);
+    }
+
+    @Test
+    void
+            mapIdentityVerificationResponseFraudCheckErrorMessageCannotBeNullWithNullResponseMessage() {
+        String responseCode = "response-code";
+        String responseMessage = null;
+        final ResponseType TYPE = ResponseType.ERROR;
+
+        IdentityVerificationResponse testIdentityVerificationResponse =
+                TestDataCreator.createTestVerificationResponse(TYPE);
+
+        ResponseHeader responseHeader = testIdentityVerificationResponse.getResponseHeader();
+        responseHeader.setResponseCode(responseCode);
+        responseHeader.setResponseMessage(responseMessage);
+
+        testIdentityVerificationResponse.setResponseHeader(responseHeader);
+
+        FraudCheckResult fraudCheckResult =
+                this.responseMapper.mapIdentityVerificationResponse(
+                        testIdentityVerificationResponse);
+
+        assertEquals(responseHeader, testIdentityVerificationResponse.getResponseHeader());
+        assertEquals(TYPE, testIdentityVerificationResponse.getResponseHeader().getResponseType());
+        assertEquals(
+                responseCode,
+                testIdentityVerificationResponse.getResponseHeader().getResponseCode());
+        assertEquals(
+                responseMessage,
+                testIdentityVerificationResponse.getResponseHeader().getResponseMessage());
+
+        final String EXPECTED_ERROR =
+                String.format(
+                        IdentityVerificationResponseMapper.IV_ERROR_RESPONSE_ERROR_MESSAGE_FORMAT,
+                        responseCode,
+                        IdentityVerificationResponseMapper
+                                .IV_ERROR_RESPONSE_ERROR_MESSAGE_DEFAULT_FIELD_VALUE_IF_BLANK);
+
+        assertNotNull(fraudCheckResult);
+        assertFalse(fraudCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
+        assertEquals(0, fraudCheckResult.getThirdPartyFraudCodes().length);
+    }
+
+    @Test
+    void
+            mapIdentityVerificationResponseFraudCheckErrorMessageCannotBeEmptyWithEmptyResponseMessage() {
+        String responseCode = "response-code";
+        String responseMessage = "";
+        final ResponseType TYPE = ResponseType.ERROR;
+
+        IdentityVerificationResponse testIdentityVerificationResponse =
+                TestDataCreator.createTestVerificationResponse(TYPE);
+
+        ResponseHeader responseHeader = testIdentityVerificationResponse.getResponseHeader();
+        responseHeader.setResponseCode(responseCode);
+        responseHeader.setResponseMessage(responseMessage);
+
+        testIdentityVerificationResponse.setResponseHeader(responseHeader);
+
+        FraudCheckResult fraudCheckResult =
+                this.responseMapper.mapIdentityVerificationResponse(
+                        testIdentityVerificationResponse);
+
+        assertEquals(responseHeader, testIdentityVerificationResponse.getResponseHeader());
+        assertEquals(TYPE, testIdentityVerificationResponse.getResponseHeader().getResponseType());
+        assertEquals(
+                responseCode,
+                testIdentityVerificationResponse.getResponseHeader().getResponseCode());
+        assertEquals(
+                responseMessage,
+                testIdentityVerificationResponse.getResponseHeader().getResponseMessage());
+
+        final String EXPECTED_ERROR =
+                String.format(
+                        IdentityVerificationResponseMapper.IV_ERROR_RESPONSE_ERROR_MESSAGE_FORMAT,
+                        responseCode,
+                        IdentityVerificationResponseMapper
+                                .IV_ERROR_RESPONSE_ERROR_MESSAGE_DEFAULT_FIELD_VALUE_IF_BLANK);
+
+        assertNotNull(fraudCheckResult);
+        assertFalse(fraudCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
+        assertEquals(0, fraudCheckResult.getThirdPartyFraudCodes().length);
     }
 }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
@@ -28,7 +28,7 @@ public class IdentityVerificationInfoResponseValidatorTest {
 
     @BeforeEach
     public void PreEachTestSetup() {
-        testIVResponse = TestDataCreator.createTestVerificationInfoResponse();
+        testIVResponse = TestDataCreator.createTestVerificationResponse(ResponseType.INFO);
     }
 
     @Test

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java
@@ -1,5 +1,7 @@
 package uk.gov.di.ipv.cri.fraud.api.util;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
@@ -12,6 +14,9 @@ import java.util.List;
 import static uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType.CURRENT;
 
 public class TestDataCreator {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
     public static PersonIdentity createTestPersonIdentity(AddressType addressType) {
         PersonIdentity personIdentity = new PersonIdentity();
         personIdentity.setDateOfBirth(LocalDate.of(1976, 12, 26));
@@ -32,11 +37,24 @@ public class TestDataCreator {
         return createTestPersonIdentity(CURRENT);
     }
 
-    public static IdentityVerificationResponse createTestVerificationInfoResponse() {
+    public static IdentityVerificationResponse createTestVerificationResponse(ResponseType type) {
+        switch (type) {
+            case INFO:
+                return createTestVerificationInfoResponse();
+            case ERROR:
+            case WARN:
+            case WARNING:
+                return createTestVerificationErrorResponse(type);
+            default:
+                throw new IllegalArgumentException("Unexpected response type encountered: " + type);
+        }
+    }
+
+    private static IdentityVerificationResponse createTestVerificationInfoResponse() {
         IdentityVerificationResponse testIVR = new IdentityVerificationResponse();
 
         ResponseHeader header = new ResponseHeader();
-        header.setRequestType("TEST_INFO_REQUEST");
+        header.setRequestType("TEST_INFO_RESPONSE");
         header.setClientReferenceId("1234567890abcdefghijklmnopqrstuvwxyz");
         header.setExpRequestId("1234");
         header.setMessageTime("2022-01-01T00:00:01Z");
@@ -100,5 +118,30 @@ public class TestDataCreator {
         testIVR.setClientResponsePayload(payload);
 
         return testIVR;
+    }
+
+    private static IdentityVerificationResponse createTestVerificationErrorResponse(
+            ResponseType type) {
+        if (type == ResponseType.INFO) {
+            String errorMessage = "Info is not an Error response Type.";
+            LOGGER.error(errorMessage);
+            throw new IllegalArgumentException(errorMessage);
+        }
+
+        IdentityVerificationResponse testErrorResponse = new IdentityVerificationResponse();
+
+        ResponseHeader header = new ResponseHeader();
+        header.setRequestType("TEST_ERROR_RESPONSE");
+        header.setClientReferenceId("1234567890abcdefghijklmnopqrstuvwxyz");
+        header.setExpRequestId("1234");
+        header.setMessageTime("2022-01-01T00:00:01Z");
+
+        header.setResponseType(type);
+        header.setResponseCode("E101");
+        header.setResponseMessage("AnErrorOccured");
+
+        testErrorResponse.setResponseHeader(header);
+
+        return testErrorResponse;
     }
 }


### PR DESCRIPTION
### What changed

Additional Unit test coverage added to ThirdPartyFraudGateway and IdentityVerificationService targeting the error pathways.

IdentityVerificationResponseMapper -
Reordered the switch statements so standard path is first, then error, then failure.
Naming in mapErrorResponse changed so that it is clear that error code or error message, used to generate the fraud check error message, will if not found be filled in with a default value.
UnitTests added for Error, Warn and Warning response types.
UnitTest added for code handling when error code, and error message is not provided.

ThirdPartyFraudGateway -
Changed error messages to be generated from final static strings so they can be used in unit testing.
Unit tests added for 300, 400, 500, and unhandled http status code paths, matching the ranges in ThirdPartyFraudGateway.

TestDataCreator - 
Added createTestVerificationResponse for UnitTesting which can be used to create INFO, Error, Warn and Warning responses.
Update previous unit tests to use new common method createTestVerificationResponse with Response type info when generating info responses within tests.
For Error, Warn and Warning Response types only a header is generated, as this contains the error code or error message.

### Why did it change

Unit tests did not fully cover the error paths within ThirdPartyFraudGateway and IdentityVerificationService.

### Issue tracking

[KBV-590](https://govukverify.atlassian.net/browse/KBV-590)