### PR TITLE
KBV-561: Adding provisioned concurrency for fraud in prod

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -72,6 +72,10 @@ Globals:
         AWS_STACK_NAME: !Sub ${AWS::StackName}
         POWERTOOLS_LOG_LEVEL: INFO
         SQS_AUDIT_EVENT_PREFIX: IPV_FRAUD_CRI
+    ProvisionedConcurrencyConfig: !If
+      - IsProdEnvironment
+      - ProvisionedConcurrentExecutions: 1
+      - !Ref AWS::NoValue
 
 Mappings:
 


### PR DESCRIPTION
## Proposed changes

### What changed

Adding provisioned concurrency in prod

### Why did it change

To align with other CRIs and improve performance

### Issue tracking

- [KBV-561](https://govukverify.atlassian.net/browse/KBV-561)

