### PR TITLE
KBV-620: Updating MaxJwtTtl in the higher envs to 2 hours

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -89,11 +89,11 @@ Mappings:
 
   MaxJwtTtlMapping:
     Environment:
-      dev: "9600" # 2 hrs
-      build: "2700" # 45 mins
-      staging: "2700"
-      integration: "2700"
-      production: "2700"
+      dev: "7200" # 2 hrs
+      build: "7200"
+      staging: "7200"
+      integration: "7200"
+      production: "7200"
 
   IPVCoreStubAuthenticationAlgMapping:
     Environment:


### PR DESCRIPTION
## Proposed changes

### What changed

Updating VC exp to 2 hours across environments

### Why did it change

To align with other CRIs and session times

### Issue tracking
- [KBV-620](https://govukverify.atlassian.net/browse/KBV-620)

