### PR TITLE
KBV-628 Allow resolving and accessing the private API from the dev en…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See onboarding guide for instructions on how to setup the following command line
 
 Before your **first** deploy, build a sam config toml file.
 > The stack name *must* be unique to you.
-> **Ensure you change the environment name**, when asked, to `dev` instead of `default`.
+> Ensure you set **Parameter Environment** and **SAM configuration environment**, when asked to `dev`.
 > All other defaults can be accepted by leaving them blank
 
 The command to run is: 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eu
 ./gradlew
-sam validate -t infrastructure/lambda/template.yaml
+sam validate -t infrastructure/lambda/template.yaml --config-env dev
 sam build -t infrastructure/lambda/template.yaml --config-env dev
-sam deploy -t infrastructure/lambda/template.yaml --config-env dev --config-file samconfig.toml --no-fail-on-empty-changeset
+sam deploy --config-file samconfig.toml --no-fail-on-empty-changeset -t infrastructure/lambda/template.yaml --config-env dev

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -276,7 +276,7 @@ Resources:
             Location: './private-api.yaml'
       OpenApiVersion: 3.0.1
       EndpointConfiguration:
-        Type: PRIVATE
+        Type: !If [IsNotDevEnvironment, PRIVATE, REGIONAL]
       Auth:
         ResourcePolicy:
           CustomStatements:
@@ -286,7 +286,7 @@ Resources:
               Resource:
                 - 'execute-api:/*'
             - Action: 'execute-api:Invoke'
-              Effect: Deny
+              Effect: !If [IsNotDevEnvironment, Deny, Allow]
               Principal: '*'
               Resource:
                 - 'execute-api:/*'


### PR DESCRIPTION
### What changed

When the Environment is dev the private API dns can be resolved and api accessed.

Remove ambiguity over the use of the value dev for two similarly named parameters in guided deployment.
Parameter Environment and SAM configuration environment must both be set to dev, for dev deployments to happen unattended.

### Why did it change

The private API was unreachable or accessible from a dev test setup without the template being modified.

There was a possibility of a user setting only the parameter environment to dev, which wrote the correct value needed for the template, but in the wrong place (default) for the deploy script to read the settings from.

### Issue tracking

- [KBV-628](https://govukverify.atlassian.net/browse/KBV-628)