### PR TITLE
KBV-649 Do not use usage plans for API Keys when the environment is dev.

### DIFF
--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -140,41 +140,6 @@ paths:
         contentHandling: "CONVERT_TO_TEXT"
         type: "aws_proxy"
 
-components:
-  schemas:
-    TokenResponse:
-      title: AccessToken
-      required:
-        - "access_token"
-        - "expires_in"
-      type: "object"
-      properties:
-        access_token:
-          type: string
-          description: The Access Token for the given token request
-        token_type:
-          type: string
-          description: The Token Type issued
-          example: Bearer
-        expires_in:
-          type: string
-          description: The expiry time, in seconds
-          example: '3600'
-        refresh_token:
-          type: string
-          description: The refresh token is optional, not currently applicable
-    Error:
-      title: "Error Schema"
-      type: "object"
-      properties:
-        message:
-          type: "string"
-  securitySchemes:
-    api_key:
-      type: "apiKey"
-      name: "x-api-key"
-      in: "header"
-
 x-amazon-apigateway-request-validators:
   Validate both:
     validateRequestBody: true

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -230,6 +230,44 @@ Resources:
           Name: AWS::Include
           Parameters:
             Location: './public-api.yaml'
+        components:
+          schemas:
+            TokenResponse:
+              title: AccessToken
+              required:
+                - "access_token"
+                - "expires_in"
+              type: "object"
+              properties:
+                access_token:
+                  type: string
+                  description: The Access Token for the given token request
+                token_type:
+                  type: string
+                  description: The Token Type issued
+                  example: Bearer
+                expires_in:
+                  type: string
+                  description: The expiry time, in seconds
+                  example: '3600'
+                refresh_token:
+                  type: string
+                  description: The refresh token is optional, not currently applicable
+            Error:
+              title: "Error Schema"
+              type: "object"
+              properties:
+                message:
+                  type: "string"
+          securitySchemes:
+            !If
+            - IsNotDevEnvironment
+            -
+              api_key:
+                type: "apiKey"
+                name: "x-api-key"
+                in: "header"
+            - !Ref "AWS::NoValue"
       OpenApiVersion: 3.0.1
       EndpointConfiguration:
         Type: REGIONAL
@@ -803,6 +841,7 @@ Resources:
       Enabled: true
 
   LinkUsagePlanApiKey1:
+    Condition: IsNotDevEnvironment
     Type: AWS::ApiGateway::UsagePlanKey
     Properties:
       KeyId: !ImportValue core-infrastructure-ApiKey1
@@ -810,6 +849,7 @@ Resources:
       UsagePlanId: !Ref PublicFraudApiUsagePlan
 
   LinkUsagePlanApiKey2:
+    Condition: IsNotDevEnvironment
     Type: AWS::ApiGateway::UsagePlanKey
     Properties:
       KeyId: !ImportValue core-infrastructure-ApiKey2


### PR DESCRIPTION
### What changed

Don't use API keys in the dev environment.

Moved AccessToken components section out of public-api.yaml back in to the public api section of template.yaml.
A header api key is now required only in the non dev environments.

### Why did it change

API Key
This avoids the issue where dev stacks fail to deploy due to too many stacks sharing the API Keys, giving the error 
 - The Usage Plan limit for  API Key core-ixxxxxxxx has been reached.

AccessToken
The public api AccessToken required an API key to be provided in the header. 
The section that controls this was being included from public-api.yaml preventing using conditional statements and variables.

### Issue tracking

- [KBV-649](https://govukverify.atlassian.net/browse/KBV-649)