### PR TITLE
KBV-633 Update VerifiableCredential removing AddressType and always r…

### DIFF
--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java
@@ -31,9 +31,11 @@ public class TestDataCreator {
             address.setValidUntil(LocalDate.now().minusMonths(1));
         }
 
-        address.setPostalCode("Postcode");
         address.setStreetName("Street Name");
         address.setAddressLocality("PostTown");
+        address.setPostalCode("Postcode");
+        address.setAddressCountry("GB");
+
         personIdentity.setAddresses(List.of(address));
         return personIdentity;
     }

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/ThirdPartyAddress.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/ThirdPartyAddress.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ThirdPartyAddress {
     private String id;
-    private String addressType;
     private String poBoxNumber;
 
     private String subBuildingName;
@@ -20,20 +19,14 @@ public class ThirdPartyAddress {
 
     private String postalCode;
 
+    private String addressCountry;
+
     public String getId() {
         return id;
     }
 
     public void setId(String id) {
         this.id = id;
-    }
-
-    public String getAddressType() {
-        return addressType;
-    }
-
-    public void setAddressType(String addressType) {
-        this.addressType = addressType;
     }
 
     public String getPoBoxNumber() {
@@ -90,5 +83,13 @@ public class ThirdPartyAddress {
 
     public void setPostalCode(String postalCode) {
         this.postalCode = postalCode;
+    }
+
+    public String getAddressCountry() {
+        return "GB";
+    }
+
+    public void setAddressCountry(String addressCountry) {
+        this.addressCountry = addressCountry;
     }
 }

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/IssueCredentialHandler.java
@@ -102,7 +102,7 @@ public class IssueCredentialHandler
             LOGGER.info("Extracted session from session store ID {}", sessionItem.getSessionId());
 
             LOGGER.info("Retrieving identity details and fraud results...");
-            var personIdentity =
+            var personIdentityDetailed =
                     personIdentityService.getPersonIdentityDetailed(sessionItem.getSessionId());
             FraudResultItem fraudResult =
                     fraudRetrievalService.getFraudResult(sessionItem.getSessionId());
@@ -111,7 +111,7 @@ public class IssueCredentialHandler
             LOGGER.info("Generating verifiable credential...");
             SignedJWT signedJWT =
                     verifiableCredentialService.generateSignedVerifiableCredentialJwt(
-                            sessionItem.getSubject(), fraudResult, personIdentity);
+                            sessionItem.getSubject(), fraudResult, personIdentityDetailed);
             auditService.sendAuditEvent(
                     AuditEventType.VC_ISSUED,
                     IssueCredentialFraudAuditExtensionUtil.generateVCISSFraudAuditExtension(

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/VerifiableCredentialService.java
@@ -39,7 +39,6 @@ public class VerifiableCredentialService {
 
     private final SignedJWTFactory signedJwtFactory;
     private final ConfigurationService configurationService;
-
     private final ObjectMapper objectMapper;
 
     public VerifiableCredentialService() {
@@ -64,7 +63,9 @@ public class VerifiableCredentialService {
     }
 
     public SignedJWT generateSignedVerifiableCredentialJwt(
-            String subject, FraudResultItem fraudResultItem, PersonIdentityDetailed personIdentity)
+            String subject,
+            FraudResultItem fraudResultItem,
+            PersonIdentityDetailed personIdentityDetailed)
             throws JOSEException {
         var now = Instant.now();
 
@@ -87,11 +88,13 @@ public class VerifiableCredentialService {
                                         VC_CREDENTIAL_SUBJECT,
                                         Map.of(
                                                 VC_ADDRESS_KEY,
-                                                convertAddresses(personIdentity.getAddresses()),
+                                                convertAddresses(
+                                                        personIdentityDetailed.getAddresses()),
                                                 VC_NAME_KEY,
-                                                personIdentity.getNames(),
+                                                personIdentityDetailed.getNames(),
                                                 VC_BIRTHDATE_KEY,
-                                                convertBirthDates(personIdentity.getBirthDates())),
+                                                convertBirthDates(
+                                                        personIdentityDetailed.getBirthDates())),
                                         VC_EVIDENCE_KEY,
                                         calculateEvidence(fraudResultItem)))
                         .build();

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/FraudPersonIdentityDetailedMapper.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/FraudPersonIdentityDetailedMapper.java
@@ -18,15 +18,24 @@ public class FraudPersonIdentityDetailedMapper {
         List<NamePart> nameParts = new ArrayList<>();
 
         if (Objects.nonNull(personIdentity.getFirstName())) {
-            nameParts.add(setNamePart(personIdentity.getFirstName(), "GivenName"));
+            NamePart givenName1 = new NamePart();
+            givenName1.setValue(personIdentity.getFirstName());
+            givenName1.setType("GivenName");
+            nameParts.add(givenName1);
         }
 
         if (Objects.nonNull(personIdentity.getMiddleNames())) {
-            nameParts.add(setNamePart(personIdentity.getMiddleNames(), "GivenName"));
+            NamePart givenName2 = new NamePart();
+            givenName2.setValue(personIdentity.getMiddleNames());
+            givenName2.setType("GivenName");
+            nameParts.add(givenName2);
         }
 
         if (Objects.nonNull(personIdentity.getSurname())) {
-            nameParts.add(setNamePart(personIdentity.getSurname(), "FamilyName"));
+            NamePart familyName = new NamePart();
+            familyName.setValue(personIdentity.getSurname());
+            familyName.setType("FamilyName");
+            nameParts.add(familyName);
         }
 
         Name name1 = new Name();
@@ -37,12 +46,5 @@ public class FraudPersonIdentityDetailedMapper {
 
         return new PersonIdentityDetailed(
                 List.of(name1), List.of(birthDate), personIdentity.getAddresses());
-    }
-
-    private static NamePart setNamePart(String value, String type) {
-        NamePart namePart = new NamePart();
-        namePart.setValue(value);
-        namePart.setType(type);
-        return namePart;
     }
 }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/VerifiableCredentialServiceTest.java
@@ -1,89 +1,124 @@
 package uk.gov.di.ipv.cri.fraud.api.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.*;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.util.SignedJWTFactory;
+import uk.gov.di.ipv.cri.fraud.api.persistence.item.FraudResultItem;
 import uk.gov.di.ipv.cri.fraud.api.service.fixtures.TestFixtures;
+import uk.gov.di.ipv.cri.fraud.api.util.FraudPersonIdentityDetailedMapper;
+import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.text.ParseException;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static uk.gov.di.ipv.cri.fraud.api.domain.VerifiableCredentialConstants.*;
 
 @ExtendWith(MockitoExtension.class)
 class VerifiableCredentialServiceTest implements TestFixtures {
-    /*public static final String SUBJECT = "subject";
-    public static final String UPRN = "72262801";
-    public static final String BUILDING_NUMBER = "8";
-    public static final String STREET_NAME = "GRANGE FIELDS WAY";
 
-    public static final String ADDRESS_LOCALITY = "LEEDS";
-    public static final String POSTAL_CODE = "LS10 4QL";
-    public static final String COUNTRY_CODE = "GB";
-    public static final LocalDate VALID_FROM = LocalDate.of(2010, 02, 26);
-    public static final LocalDate VALID_UNTIL = LocalDate.of(2021, 01, 16);
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private final String UNIT_TEST_VC_ISSUER = "UNIT_TEST_VC_ISSUER";
+    private final long UNIT_TEST_MAX_JWT_TTL = 100L;
+    private final String UNIT_TEST_SUBJECT = "UNIT_TEST_SUBJECT";
+
+    private final String TEST_KEY = "UNIT_TEST_KEY";
+
     @Mock private ConfigurationService mockConfigurationService;
 
+    private ObjectMapper objectMapper;
+
+    private VerifiableCredentialService verifiableCredentialService;
+
     @BeforeEach
-    void setUp() {
-        when(mockConfigurationService.getVerifiableCredentialIssuer())
-                .thenReturn("https://address-cri.account.gov.uk.TBC");
-    }
-
-    @Test
-    void shouldReturnAVerifiedCredentialWhenGivenCanonicalAddresses() throws JOSEException {
-        SignedJWTFactory mockSignedClaimSetJwt = mock(SignedJWTFactory.class);
-        var verifiableCredentialService =
-                new VerifiableCredentialService(mockSignedClaimSetJwt, mockConfigurationService);
-
-        when(mockConfigurationService.getVerifiableCredentialIssuer())
-                .thenReturn("address-cri-issue");
-        when(mockConfigurationService.getMaxJwtTtl()).thenReturn(342L);
-
-        var canonicalAddresses = List.of(mock(CanonicalAddress.class));
-
-        verifiableCredentialService.generateSignedVerifiableCredentialJwt(
-                SUBJECT, canonicalAddresses);
-
-        verify(mockSignedClaimSetJwt).createSignedJwt(any());
-    }
-
-    @Test
-    void shouldCreateValidSignedJWT()
-            throws InvalidKeySpecException, NoSuchAlgorithmException, JOSEException, ParseException,
-                    JsonProcessingException {
-
-        CanonicalAddress address = new CanonicalAddress();
-        address.setUprn(Long.valueOf(UPRN));
-        address.setBuildingNumber(BUILDING_NUMBER);
-        address.setStreetName(STREET_NAME);
-        address.setAddressLocality(ADDRESS_LOCALITY);
-        address.setPostalCode(POSTAL_CODE);
-        address.setAddressCountry(COUNTRY_CODE);
-        address.setValidFrom(VALID_FROM);
-        address.setValidUntil(VALID_UNTIL);
-        List<CanonicalAddress> canonicalAddresses = List.of(address);
+    void setup() throws JOSEException, InvalidKeySpecException, NoSuchAlgorithmException {
 
         SignedJWTFactory signedJwtFactory = new SignedJWTFactory(new ECDSASigner(getPrivateKey()));
-        var verifiableCredentialService =
-                new VerifiableCredentialService(signedJwtFactory, mockConfigurationService);
+
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        verifiableCredentialService =
+                new VerifiableCredentialService(
+                        signedJwtFactory, mockConfigurationService, objectMapper);
+    }
+
+    @Test
+    void testGenerateSignedVerifiableCredentialJwt()
+            throws JOSEException, JsonProcessingException, ParseException {
+        FraudResultItem fraudResultItem = new FraudResultItem(UUID.randomUUID(), List.of("A01"), 1);
+
+        PersonIdentityDetailed personIdentityDetailed =
+                FraudPersonIdentityDetailedMapper.generatePersonIdentityDetailed(
+                        TestDataCreator.createTestPersonIdentity());
+
+        when(mockConfigurationService.getVerifiableCredentialIssuer())
+                .thenReturn(UNIT_TEST_VC_ISSUER);
+        when(mockConfigurationService.getMaxJwtTtl()).thenReturn(UNIT_TEST_MAX_JWT_TTL);
 
         SignedJWT signedJWT =
                 verifiableCredentialService.generateSignedVerifiableCredentialJwt(
-                        SUBJECT, canonicalAddresses);
+                        UNIT_TEST_SUBJECT, fraudResultItem, personIdentityDetailed);
+
         JWTClaimsSet generatedClaims = signedJWT.getJWTClaimsSet();
         assertTrue(signedJWT.verify(new ECDSAVerifier(ECKey.parse(TestFixtures.EC_PUBLIC_JWK_1))));
 
-        JsonNode claimsSet = objectMapper.readTree(generatedClaims.toString());
+        String jsonGeneratedClaims =
+                objectMapper
+                        .writer()
+                        .withDefaultPrettyPrinter()
+                        .writeValueAsString(generatedClaims);
+        LOGGER.info(jsonGeneratedClaims);
 
+        String issuer = verifiableCredentialService.getVerifiableCredentialIssuer();
+        assertEquals(UNIT_TEST_VC_ISSUER, issuer);
+
+        JsonNode claimsSet = objectMapper.readTree(generatedClaims.toString());
         assertEquals(5, claimsSet.size());
+
+        Address address = personIdentityDetailed.getAddresses().get(0);
 
         assertAll(
                 () -> {
                     assertEquals(
-                            address.getUprn().get().toString(),
+                            fraudResultItem.getContraIndicators().get(0),
                             claimsSet
                                     .get(VC_CLAIM)
-                                    .get(VC_CREDENTIAL_SUBJECT)
-                                    .get(VC_ADDRESS_KEY)
+                                    .get(VC_EVIDENCE_KEY)
                                     .get(0)
-                                    .get("uprn")
+                                    .get("ci")
+                                    .get(0)
                                     .asText());
+                    assertEquals(
+                            fraudResultItem.getIdentityFraudScore(),
+                            claimsSet
+                                    .get(VC_CLAIM)
+                                    .get(VC_EVIDENCE_KEY)
+                                    .get(0)
+                                    .get("identityFraudScore")
+                                    .asInt());
                     assertEquals(
                             address.getBuildingNumber(),
                             claimsSet
@@ -129,26 +164,15 @@ class VerifiableCredentialServiceTest implements TestFixtures {
                                     .get(0)
                                     .get("addressCountry")
                                     .asText());
-                    assertEquals(
-                            "2010-02-26",
-                            claimsSet
-                                    .get(VC_CLAIM)
-                                    .get(VC_CREDENTIAL_SUBJECT)
-                                    .get(VC_ADDRESS_KEY)
-                                    .get(0)
-                                    .get("validFrom")
-                                    .asText());
-                    assertEquals(
-                            "2021-01-16",
-                            claimsSet
-                                    .get(VC_CLAIM)
-                                    .get(VC_CREDENTIAL_SUBJECT)
-                                    .get(VC_ADDRESS_KEY)
-                                    .get(0)
-                                    .get("validUntil")
-                                    .asText());
                 });
+        assertEquals(UNIT_TEST_VC_ISSUER, claimsSet.get("iss").textValue());
+        assertEquals(UNIT_TEST_SUBJECT, claimsSet.get("sub").textValue());
+
+        long notBeforeTime = claimsSet.get("nbf").asLong();
+        final long expirationTime = claimsSet.get("exp").asLong();
+        assertEquals(expirationTime, notBeforeTime + UNIT_TEST_MAX_JWT_TTL);
+
         ECDSAVerifier ecVerifier = new ECDSAVerifier(ECKey.parse(TestFixtures.EC_PUBLIC_JWK_1));
         assertTrue(signedJWT.verify(ecVerifier));
-    }*/
+    }
 }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java
@@ -1,0 +1,45 @@
+package uk.gov.di.ipv.cri.fraud.api.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType.CURRENT;
+
+public class TestDataCreator {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public static PersonIdentity createTestPersonIdentity(AddressType addressType) {
+        PersonIdentity personIdentity = new PersonIdentity();
+
+        personIdentity.setFirstName("FirstName");
+        personIdentity.setMiddleNames("MiddleName");
+        personIdentity.setSurname("Surname");
+
+        personIdentity.setDateOfBirth(LocalDate.of(1976, 12, 26));
+        Address address = new Address();
+        address.setValidFrom(LocalDate.now().minusYears(3));
+        if (addressType.equals(AddressType.PREVIOUS)) {
+            address.setValidUntil(LocalDate.now().minusMonths(1));
+        }
+
+        address.setBuildingNumber("101");
+        address.setStreetName("Street Name");
+        address.setAddressLocality("PostTown");
+        address.setPostalCode("Postcode");
+        address.setAddressCountry("GB");
+
+        personIdentity.setAddresses(List.of(address));
+        return personIdentity;
+    }
+
+    public static PersonIdentity createTestPersonIdentity() {
+        return createTestPersonIdentity(CURRENT);
+    }
+}


### PR DESCRIPTION
### What changed

Removed AddressType from ThirdPartyAddress.java (used to map to the address format for the VC)
Added AddressCountry to ThirdPartyAddress.java.
getAddressCountry will always return hardcoded value of GB.

Fixed some variable naming issues when referring to a personIdentityDetailed as personIdentity.

Unit test added for generating a signed verifiable credential JWT via verifiableCredentialService.
Added two helper classes to generate a personIdentity and map to a personIdentityDetailed for the unit test.

### Why did it change

AddressType was being returned in the verifiableCredential and should not.
AddressCountry was not being returned in the verifiableCredential, but wasn't.
AddressCountry is hardcoded to GB per KBV-633.

The unit test for generating the signed verifiable credential was incomplete and disabled.

### Issue tracking

- [KBV-633](https://govukverify.atlassian.net/browse/KBV-633)