### PR TITLE
KBV-520 Send multiple addresses to Experian

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/PersonIdentityValidator.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/PersonIdentityValidator.java
@@ -20,6 +20,12 @@ class PersonIdentityValidator {
         if (Objects.isNull(personIdentity.getDateOfBirth())) {
             validationErrors.add("date of birth must not be null");
         }
+        if (Objects.isNull(personIdentity.getAddresses())) {
+            validationErrors.add("Addresses must not be null");
+        } else if (personIdentity.getAddresses().isEmpty()) {
+            validationErrors.add("Addresses must not be empty");
+        }
+
         // this implementation needs completing to validate all necessary fields
         return new ValidationResult<>(validationErrors.isEmpty(), validationErrors);
     }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationRequestMapperTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationRequestMapperTest.java
@@ -2,19 +2,25 @@ package uk.gov.di.ipv.cri.fraud.api.gateway;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.Address;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.IdentityVerificationRequest;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.Person;
 import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType.CURRENT;
 import static uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType.PREVIOUS;
 
 class IdentityVerificationRequestMapperTest {
+
+    private static final int ADDRESSES_TO_GENERATE_IN_TEST = 5;
 
     private static final String TENANT_ID = "tenant-id";
     private IdentityVerificationRequestMapper requestMapper;
@@ -35,56 +41,25 @@ class IdentityVerificationRequestMapperTest {
         IdentityVerificationRequest result = requestMapper.mapPersonIdentity(personIdentity);
 
         assertNotNull(result);
+
+        Person person = result.getPayload().getContacts().get(0).getPerson();
+
         assertEquals(
-                LocalDate.of(1976, 12, 26).toString(),
-                result.getPayload()
-                        .getContacts()
-                        .get(0)
-                        .getPerson()
-                        .getPersonDetails()
-                        .getDateOfBirth());
-        assertEquals(
-                personIdentity.getFirstName(),
-                result.getPayload()
-                        .getContacts()
-                        .get(0)
-                        .getPerson()
-                        .getNames()
-                        .get(0)
-                        .getFirstName());
-        assertEquals(
-                personIdentity.getSurname(),
-                result.getPayload()
-                        .getContacts()
-                        .get(0)
-                        .getPerson()
-                        .getNames()
-                        .get(0)
-                        .getSurName());
+                LocalDate.of(1976, 12, 26).toString(), person.getPersonDetails().getDateOfBirth());
+        assertEquals(personIdentity.getFirstName(), person.getNames().get(0).getFirstName());
+        assertEquals(personIdentity.getSurname(), person.getNames().get(0).getSurName());
 
         assertEquals("WEB", result.getPayload().getSource());
 
-        assertEquals(
-                CURRENT.toString(),
-                result.getPayload().getContacts().get(0).getAddresses().get(0).getAddressType());
-        assertEquals(
-                "PostTown",
-                result.getPayload().getContacts().get(0).getAddresses().get(0).getPostTown());
-        assertEquals(
-                "Street Name",
-                result.getPayload().getContacts().get(0).getAddresses().get(0).getStreet());
-        assertEquals(
-                "Postcode",
-                result.getPayload().getContacts().get(0).getAddresses().get(0).getPostal());
-        assertEquals(
-                "Building One",
-                result.getPayload().getContacts().get(0).getAddresses().get(0).getSubBuilding());
-        assertEquals(
-                "House Name",
-                result.getPayload().getContacts().get(0).getAddresses().get(0).getBuildingName());
-        assertEquals(
-                "44",
-                result.getPayload().getContacts().get(0).getAddresses().get(0).getBuildingNumber());
+        Address address = result.getPayload().getContacts().get(0).getAddresses().get(0);
+
+        assertEquals(CURRENT.toString(), address.getAddressType());
+        assertEquals("PostTown", address.getPostTown());
+        assertEquals("Street Name", address.getStreet());
+        assertEquals("Postcode", address.getPostal());
+        assertEquals("Building One", address.getSubBuilding());
+        assertEquals("House Name", address.getBuildingName());
+        assertEquals("44", address.getBuildingNumber());
     }
 
     @Test
@@ -94,47 +69,57 @@ class IdentityVerificationRequestMapperTest {
         IdentityVerificationRequest result = requestMapper.mapPersonIdentity(personIdentity);
 
         assertNotNull(result);
+
+        Person person = result.getPayload().getContacts().get(0).getPerson();
+
         assertEquals(
-                LocalDate.of(1976, 12, 26).toString(),
-                result.getPayload()
-                        .getContacts()
-                        .get(0)
-                        .getPerson()
-                        .getPersonDetails()
-                        .getDateOfBirth());
-        assertEquals(
-                personIdentity.getFirstName(),
-                result.getPayload()
-                        .getContacts()
-                        .get(0)
-                        .getPerson()
-                        .getNames()
-                        .get(0)
-                        .getFirstName());
-        assertEquals(
-                personIdentity.getSurname(),
-                result.getPayload()
-                        .getContacts()
-                        .get(0)
-                        .getPerson()
-                        .getNames()
-                        .get(0)
-                        .getSurName());
+                LocalDate.of(1976, 12, 26).toString(), person.getPersonDetails().getDateOfBirth());
+        assertEquals(personIdentity.getFirstName(), person.getNames().get(0).getFirstName());
+        assertEquals(personIdentity.getSurname(), person.getNames().get(0).getSurName());
 
         assertEquals("WEB", result.getPayload().getSource());
 
+        Address address = result.getPayload().getContacts().get(0).getAddresses().get(0);
+
+        assertEquals(PREVIOUS.toString(), address.getAddressType());
+        assertEquals("PostTown", address.getPostTown());
+        assertEquals("Street Name", address.getStreet());
+        assertEquals("Postcode", address.getPostal());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getAddressCount")
+    void shouldConvertPersonIdentityToCrossCoreApiRequestWithAddressCount(int addressCount) {
+
+        personIdentity = TestDataCreator.createTestPersonIdentityMultipleAddresses(addressCount);
+
+        IdentityVerificationRequest result = requestMapper.mapPersonIdentity(personIdentity);
+
+        assertNotNull(result);
+
+        Person person = result.getPayload().getContacts().get(0).getPerson();
+
         assertEquals(
-                PREVIOUS.toString(),
-                result.getPayload().getContacts().get(0).getAddresses().get(0).getAddressType());
-        assertEquals(
-                "PostTown",
-                result.getPayload().getContacts().get(0).getAddresses().get(0).getPostTown());
-        assertEquals(
-                "Street Name",
-                result.getPayload().getContacts().get(0).getAddresses().get(0).getStreet());
-        assertEquals(
-                "Postcode",
-                result.getPayload().getContacts().get(0).getAddresses().get(0).getPostal());
+                LocalDate.of(1976, 12, 26).toString(), person.getPersonDetails().getDateOfBirth());
+        assertEquals(personIdentity.getFirstName(), person.getNames().get(0).getFirstName());
+        assertEquals(personIdentity.getSurname(), person.getNames().get(0).getSurName());
+
+        assertEquals("WEB", result.getPayload().getSource());
+
+        assertNotEquals(0, addressCount);
+
+        List<Address> addresses = result.getPayload().getContacts().get(0).getAddresses();
+
+        IntStream.range(0, addressCount)
+                .forEach(
+                        a -> {
+                            assertEquals(
+                                    a == 0 ? CURRENT.toString() : PREVIOUS.toString(),
+                                    addresses.get(a).getAddressType());
+                            assertEquals("PostTown" + a, addresses.get(a).getPostTown());
+                            assertEquals("Street Name" + a, addresses.get(a).getStreet());
+                            assertEquals("Postcode" + a, addresses.get(a).getPostal());
+                        });
     }
 
     @Test
@@ -144,5 +129,9 @@ class IdentityVerificationRequestMapperTest {
                         NullPointerException.class,
                         () -> requestMapper.mapPersonIdentity(personIdentity));
         assertEquals("The personIdentity must not be null", exception.getMessage());
+    }
+
+    private static int[] getAddressCount() {
+        return IntStream.range(1, ADDRESSES_TO_GENERATE_IN_TEST).toArray();
     }
 }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java
@@ -10,6 +10,7 @@ import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType.CURRENT;
 
@@ -31,6 +32,7 @@ public class TestDataCreator {
             address.setValidUntil(LocalDate.now().minusMonths(1));
         }
 
+        address.setBuildingNumber("101");
         address.setStreetName("Street Name");
         address.setAddressLocality("PostTown");
         address.setPostalCode("Postcode");
@@ -44,6 +46,27 @@ public class TestDataCreator {
         return createTestPersonIdentity(CURRENT);
     }
 
+    public static PersonIdentity createTestPersonIdentityMultipleAddresses(int totalAddresses) {
+        PersonIdentity personIdentity = new PersonIdentity();
+
+        personIdentity.setFirstName("FirstName");
+        personIdentity.setMiddleNames("MiddleName");
+        personIdentity.setSurname("Surname");
+
+        personIdentity.setDateOfBirth(LocalDate.of(1976, 12, 26));
+
+        List<Address> addresses = new ArrayList<>();
+        IntStream.range(0, totalAddresses)
+                .forEach(
+                        a -> {
+                            addresses.add(createAddress(a));
+                        });
+
+        personIdentity.setAddresses(addresses);
+
+        return personIdentity;
+    }
+
     public static IdentityVerificationResponse createTestVerificationResponse(ResponseType type) {
         switch (type) {
             case INFO:
@@ -55,6 +78,37 @@ public class TestDataCreator {
             default:
                 throw new IllegalArgumentException("Unexpected response type encountered: " + type);
         }
+    }
+
+    private static Address createAddress(int id) {
+
+        Address address = new Address();
+
+        final int yearsBetweenAddresses = 2;
+
+        int startYear = id + (id + yearsBetweenAddresses);
+        int endYear = id + id;
+
+        address.setValidFrom(LocalDate.now().minusYears(startYear));
+
+        address.setValidUntil(
+                (id == 0 ? null : LocalDate.now().minusYears(endYear).minusMonths(1)));
+
+        address.setPostalCode("Postcode" + id);
+        address.setStreetName("Street Name" + id);
+        address.setAddressLocality("PostTown" + id);
+
+        LOGGER.info(
+                "createAddress "
+                        + id
+                        + " "
+                        + address.getAddressType()
+                        + " from "
+                        + address.getValidFrom()
+                        + " until "
+                        + address.getValidUntil());
+
+        return address;
     }
 
     private static IdentityVerificationResponse createTestVerificationInfoResponse() {

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java
@@ -7,7 +7,9 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType.CURRENT;
 
@@ -41,5 +43,58 @@ public class TestDataCreator {
 
     public static PersonIdentity createTestPersonIdentity() {
         return createTestPersonIdentity(CURRENT);
+    }
+
+    public static PersonIdentity createTestPersonIdentityMultipleAddresses(int totalAddresses) {
+        PersonIdentity personIdentity = new PersonIdentity();
+
+        personIdentity.setFirstName("FirstName");
+        personIdentity.setMiddleNames("MiddleName");
+        personIdentity.setSurname("Surname");
+
+        personIdentity.setDateOfBirth(LocalDate.of(1976, 12, 26));
+
+        List<Address> addresses = new ArrayList<>();
+        IntStream.range(0, totalAddresses)
+                .forEach(
+                        a -> {
+                            addresses.add(createAddress(a));
+                        });
+
+        personIdentity.setAddresses(addresses);
+
+        return personIdentity;
+    }
+
+    private static Address createAddress(int id) {
+
+        Address address = new Address();
+
+        final int yearsBetweenAddresses = 2;
+
+        int startYear = id + (id + yearsBetweenAddresses);
+        int endYear = id + id;
+
+        address.setValidFrom(LocalDate.now().minusYears(startYear));
+
+        address.setValidUntil(
+                (id == 0 ? null : LocalDate.now().minusYears(endYear).minusMonths(1)));
+
+        address.setBuildingNumber(String.valueOf((id + 100)));
+        address.setPostalCode("Postcode" + id);
+        address.setStreetName("Street Name" + id);
+        address.setAddressLocality("PostTown" + id);
+
+        LOGGER.info(
+                "createAddress "
+                        + id
+                        + " "
+                        + address.getAddressType()
+                        + " from "
+                        + address.getValidFrom()
+                        + " until "
+                        + address.getValidUntil());
+
+        return address;
     }
 }


### PR DESCRIPTION
### What changed

Added unit test to prove that an IdentityVerificationRequest can be created with two or more addresses.

Updated the SignedVerifiableCredentialJWT unit test to prove that a signed JWT VC can be created with two or more addresses.

Added a check to the PersonIdentityValidator to fail users with 0 addresses.

Readability improvements in IdentityVerificationRequestMapperTest.

### Why did it change

It was unknown if FraudCRI-API could handle multiple address.
As no test user currently has two addresses, a VC for a user with two address was generated using an adhoc solution with evidence attached in KBV-520.

Users with 0 addresses would fail the fraud check, this fails the user for this error condition earlier.

IdentityVerificationRequestMapperTest had excessive duplication of object paths.

### Issue tracking

- [KBV-520](https://govukverify.atlassian.net/browse/KBV-520)