### PR TITLE
KBV-629 Remove contraindicationMappingTableName from ConfigurationSer…

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationService.java
@@ -43,7 +43,6 @@ public class ConfigurationService {
     private final String encodedKeyStore;
     private final String keyStorePassword;
     private final String thirdPartyId;
-    private final String contraindicationMappingTableName;
     private final String fraudResultTableName;
     private final String contraindicationMappings;
     private final String parameterPrefix;
@@ -62,9 +61,6 @@ public class ConfigurationService {
                 paramProvider.get(String.format(KEY_FORMAT, env, "thirdPartyApiEndpointUrl"));
         this.hmacKey = secretsProvider.get(String.format(KEY_FORMAT, env, "thirdPartyApiHmacKey"));
         this.thirdPartyId = paramProvider.get(String.format(KEY_FORMAT, env, "thirdPartyId"));
-        this.contraindicationMappingTableName =
-                paramProvider.get(
-                        String.format(KEY_FORMAT, env, "contraindicationMappingTableName"));
 
         this.parameterPrefix = System.getenv("AWS_STACK_NAME");
         this.contraindicationMappings =
@@ -104,10 +100,6 @@ public class ConfigurationService {
 
     public String getThirdPartyId() {
         return thirdPartyId;
-    }
-
-    public String getContraindicationMappingTableName() {
-        return contraindicationMappingTableName;
     }
 
     public String getFraudResultTableName() {

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationServiceTest.java
@@ -34,8 +34,6 @@ class ConfigurationServiceTest {
         String endpointValue = "test-endpoint";
         String thirdPartyIdKey = "thirdPartyId";
         String thirdPartyIdValue = "third-party-id";
-        String tableNameKey = "contraindicationMappingTableName";
-        String tableNameValue = "test-table-name";
         String keyStoreKey = "thirdPartyApiKeyStore";
 
         ConfigurationService.KeyStoreParams testKeyStoreParams =
@@ -49,8 +47,6 @@ class ConfigurationServiceTest {
                 .thenReturn(endpointValue);
         when(mockParamProvider.get(String.format(KEY_FORMAT, env, thirdPartyIdKey)))
                 .thenReturn(thirdPartyIdValue);
-        when(mockParamProvider.get(String.format(KEY_FORMAT, env, tableNameKey)))
-                .thenReturn(tableNameValue);
 
         when(mockSecretsProvider.get(String.format(KEY_FORMAT, env, hmacKey)))
                 .thenReturn(testHmacKeyValue);
@@ -67,7 +63,6 @@ class ConfigurationServiceTest {
         verify(mockParamProvider).get(String.format(KEY_FORMAT, env, tenantIdKey));
         verify(mockParamProvider).get(String.format(KEY_FORMAT, env, endpointKey));
         verify(mockParamProvider).get(String.format(KEY_FORMAT, env, thirdPartyIdKey));
-        verify(mockParamProvider).get(String.format(KEY_FORMAT, env, tableNameKey));
         verify(mockSecretsProvider).get(String.format(KEY_FORMAT, env, hmacKey));
         verify(mockSecretsProvider)
                 .get(
@@ -80,7 +75,6 @@ class ConfigurationServiceTest {
         assertEquals(testHmacKeyValue, configurationService.getHmacKey());
         assertEquals(thirdPartyIdValue, configurationService.getThirdPartyId());
         assertEquals(endpointValue, configurationService.getEndpointUrl());
-        assertEquals(tableNameValue, configurationService.getContraindicationMappingTableName());
         assertEquals(tenantIdValue, configurationService.getTenantId());
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed

Removed contraindicationMappingTableName from FraudCRI ConfigurationService.

### Why did it change

The parameter is no longer used and was removed from the template in PR https://github.com/alphagov/di-ipv-cri-fraud-api/pull/42

### Issue tracking



- [KBV-629](https://govukverify.atlassian.net/browse/KBV-629)