### PR TITLE
Bump memory to 2Gb

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -68,7 +68,7 @@ Globals:
     Runtime: java11
     AutoPublishAlias: live
     Tracing: Active
-    MemorySize: 512
+    MemorySize: 2048
     Environment:
       Variables:
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1


### PR DESCRIPTION
Other teams seem to be stabilising on 2048Mb for memory size.

On Lambda, CPU scales with memory, so more memory means more CPU as well.

See alphagov/di-ipv-cri-address-api#163
and alphagov/di-ipv-cri-kbv-api#144
and alphagov/di-ipv-core-back#300
and alphagov/di-ipv-spot/pull/307


### What changed

from 512Mb to 2048Mb
