### PR TITLE
KBV-771 Validate address information prior to fraud check.

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/PersonIdentityValidator.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/PersonIdentityValidator.java
@@ -1,32 +1,115 @@
 package uk.gov.di.ipv.cri.fraud.api.service;
 
-import com.nimbusds.oauth2.sdk.util.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.fraud.api.domain.ValidationResult;
+import uk.gov.di.ipv.cri.fraud.api.util.JsonValidationUtility;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 class PersonIdentityValidator {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    public static final int MIN_SUPPORTED_ADDRESSES = 1;
+    public static final int MAX_SUPPORTED_ADDRESSES = 32;
+    private static final int NAME_STRING_MAX_LEN = 1024;
+    private static final String ADDRESSES_CHECK_ERROR =
+            "Address validation error - %d addresses found %d CURRENT, %d PREVIOUS and %d INVALID.";
+    private static final String ADDRESSES_INFO_MESSAGE =
+            "Address validation - %d addresses found %d CURRENT, %d PREVIOUS.";
+
     ValidationResult<List<String>> validate(PersonIdentity personIdentity) {
         List<String> validationErrors = new ArrayList<>();
-        if (StringUtils.isBlank(personIdentity.getFirstName())) {
-            validationErrors.add("firstname must not be null or empty");
-        }
-        if (StringUtils.isBlank(personIdentity.getSurname())) {
-            validationErrors.add("surname must not be null or empty");
-        }
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                personIdentity.getFirstName(), NAME_STRING_MAX_LEN, "FirstName", validationErrors);
+
+        JsonValidationUtility.validateStringDataEmptyIsFail(
+                personIdentity.getSurname(), NAME_STRING_MAX_LEN, "Surname", validationErrors);
+
         if (Objects.isNull(personIdentity.getDateOfBirth())) {
-            validationErrors.add("date of birth must not be null");
+            validationErrors.add(
+                    "DateOfBirth" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX);
         }
+
         if (Objects.isNull(personIdentity.getAddresses())) {
-            validationErrors.add("Addresses must not be null");
-        } else if (personIdentity.getAddresses().isEmpty()) {
-            validationErrors.add("Addresses must not be empty");
+            validationErrors.add("Addresses" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX);
+        } else if (JsonValidationUtility.validateIntegerRangeData(
+                personIdentity.getAddresses().size(),
+                MIN_SUPPORTED_ADDRESSES,
+                MAX_SUPPORTED_ADDRESSES,
+                "Addresses",
+                validationErrors)) {
+
+            // Ensure addresses can be evaluated correctly
+            validationErrors.addAll(checkAddresses(personIdentity.getAddresses()));
         }
 
         // this implementation needs completing to validate all necessary fields
         return new ValidationResult<>(validationErrors.isEmpty(), validationErrors);
+    }
+
+    private List<String> checkAddresses(List<Address> addresses) {
+
+        List<String> validationErrors = new ArrayList<>();
+
+        int currentAddressCount = 0;
+        int previousAddressCount = 0;
+        int errorAddressCount = 0;
+
+        for (Address address : addresses) {
+
+            AddressType addressType = address.getAddressType();
+
+            if (addressType == AddressType.CURRENT) {
+                currentAddressCount++;
+            } else if (addressType == AddressType.PREVIOUS) {
+                previousAddressCount++;
+            } else {
+                errorAddressCount++;
+            }
+        }
+
+        if ((currentAddressCount == 0) || (errorAddressCount > 0)) {
+            validationErrors.add(
+                    createAddressCheckErrorMessage(
+                            addresses.size(),
+                            currentAddressCount,
+                            previousAddressCount,
+                            errorAddressCount));
+        } else {
+
+            String addressInfoMessage =
+                    createAddressInfoMessage(
+                            addresses.size(), currentAddressCount, previousAddressCount);
+
+            LOGGER.info(addressInfoMessage);
+        }
+
+        return validationErrors;
+    }
+
+    private String createAddressInfoMessage(
+            int addressCount, int currentAddressCount, int previousAddressCount) {
+        return String.format(
+                ADDRESSES_INFO_MESSAGE, addressCount, currentAddressCount, previousAddressCount);
+    }
+
+    public static String createAddressCheckErrorMessage(
+            int addressCount,
+            int currentAddressCount,
+            int previousAddressCount,
+            int errorAddressCount) {
+        return String.format(
+                ADDRESSES_CHECK_ERROR,
+                addressCount,
+                currentAddressCount,
+                previousAddressCount,
+                errorAddressCount);
     }
 }

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/JsonValidationUtility.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/JsonValidationUtility.java
@@ -10,8 +10,8 @@ public final class JsonValidationUtility {
     public static final String IS_NULL_ERROR_MESSAGE_SUFFIX = " not found.";
     public static final String IS_EMPTY_ERROR_MESSAGE_SUFFIX = " is empty.";
     public static final String IS_TOO_LONG_ERROR_MESSAGE_SUFFIX = " is too long.";
-    public static final String INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX =
-            " is outside the valid range.";
+    public static final String INVALID_VALUE_RANGE_ERROR_MESSAGE_FORMAT =
+            "%s (%d) is outside the valid range (%d-%d).";
     public static final String FAIL_PARSING_TIMESTAMP_ERROR_MESSAGE_SUFFIX =
             " failed timestamp parsing.";
 
@@ -169,10 +169,20 @@ public final class JsonValidationUtility {
     public static boolean validateIntegerRangeData(
             int variable, int min, int max, String name, final List<String> validationErrors) {
         if (variable < min || variable > max) {
-            validationErrors.add(name + INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX);
+            validationErrors.add(createIntegerRangeErrorMessage(variable, min, max, name));
             return false;
         }
 
         return true;
+    }
+
+    public static String createIntegerRangeErrorMessage(
+            int variable, int min, int max, String name) {
+        return String.format(
+                JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_FORMAT,
+                name,
+                variable,
+                min,
+                max);
     }
 }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationRequestMapperTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationRequestMapperTest.java
@@ -14,7 +14,10 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType.CURRENT;
 import static uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType.PREVIOUS;
 
@@ -91,7 +94,9 @@ class IdentityVerificationRequestMapperTest {
     @MethodSource("getAddressCount")
     void shouldConvertPersonIdentityToCrossCoreApiRequestWithAddressCount(int addressCount) {
 
-        personIdentity = TestDataCreator.createTestPersonIdentityMultipleAddresses(addressCount);
+        personIdentity =
+                TestDataCreator.createTestPersonIdentityMultipleAddresses(
+                        addressCount, 0, 0, false);
 
         IdentityVerificationRequest result = requestMapper.mapPersonIdentity(personIdentity);
 

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
@@ -14,7 +14,10 @@ import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IdentityVerificationInfoResponseValidatorTest {
     private static IdentityVerificationInfoResponseValidator infoResponseValidator;
@@ -391,9 +394,16 @@ public class IdentityVerificationInfoResponseValidatorTest {
         ValidationResult<List<String>> validationResult =
                 infoResponseValidator.validate(testIVResponse);
 
+        final String TEST_INTEGER_NAME = "OverallResponse:Score";
+
         final String EXPECTED_ERROR =
-                "OverallResponse:Score"
-                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+                JsonValidationUtility.createIntegerRangeErrorMessage(
+                        TEST_VALUE,
+                        IdentityVerificationInfoResponseValidator
+                                .OVERALL_RESPONSE_DECISION_SCORE_MIN_VALUE,
+                        IdentityVerificationInfoResponseValidator
+                                .OVERALL_RESPONSE_DECISION_SCORE_MAX_VALUE,
+                        TEST_INTEGER_NAME);
 
         assertEquals(
                 TEST_VALUE, testIVResponse.getResponseHeader().getOverallResponse().getScore());
@@ -438,9 +448,16 @@ public class IdentityVerificationInfoResponseValidatorTest {
         ValidationResult<List<String>> validationResult =
                 infoResponseValidator.validate(testIVResponse);
 
+        final String TEST_INTEGER_NAME = "OverallResponse:Score";
+
         final String EXPECTED_ERROR =
-                "OverallResponse:Score"
-                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+                JsonValidationUtility.createIntegerRangeErrorMessage(
+                        TEST_VALUE,
+                        IdentityVerificationInfoResponseValidator
+                                .OVERALL_RESPONSE_DECISION_SCORE_MIN_VALUE,
+                        IdentityVerificationInfoResponseValidator
+                                .OVERALL_RESPONSE_DECISION_SCORE_MAX_VALUE,
+                        TEST_INTEGER_NAME);
 
         assertEquals(
                 TEST_VALUE, testIVResponse.getResponseHeader().getOverallResponse().getScore());
@@ -1470,9 +1487,16 @@ public class IdentityVerificationInfoResponseValidatorTest {
         ValidationResult<List<String>> validationResult =
                 infoResponseValidator.validate(testIVResponse);
 
+        final String TEST_INTEGER_NAME = "OrchestrationDecision:Score";
+
         final String EXPECTED_ERROR =
-                "OrchestrationDecision:Score"
-                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+                JsonValidationUtility.createIntegerRangeErrorMessage(
+                        TEST_VALUE,
+                        IdentityVerificationInfoResponseValidator
+                                .ORCHESTRATION_DECISION_SCORE_MIN_VALUE,
+                        IdentityVerificationInfoResponseValidator
+                                .ORCHESTRATION_DECISION_SCORE_MAX_VALUE,
+                        TEST_INTEGER_NAME);
 
         assertEquals(
                 TEST_VALUE,
@@ -1521,9 +1545,16 @@ public class IdentityVerificationInfoResponseValidatorTest {
         ValidationResult<List<String>> validationResult =
                 infoResponseValidator.validate(testIVResponse);
 
+        final String TEST_INTEGER_NAME = "OrchestrationDecision:Score";
+
         final String EXPECTED_ERROR =
-                "OrchestrationDecision:Score"
-                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+                JsonValidationUtility.createIntegerRangeErrorMessage(
+                        TEST_VALUE,
+                        IdentityVerificationInfoResponseValidator
+                                .ORCHESTRATION_DECISION_SCORE_MIN_VALUE,
+                        IdentityVerificationInfoResponseValidator
+                                .ORCHESTRATION_DECISION_SCORE_MAX_VALUE,
+                        TEST_INTEGER_NAME);
 
         assertEquals(
                 TEST_VALUE,
@@ -2183,9 +2214,14 @@ public class IdentityVerificationInfoResponseValidatorTest {
         ValidationResult<List<String>> validationResult =
                 infoResponseValidator.validate(testIVResponse);
 
+        final String TEST_INTEGER_NAME = "DecisionElement:Score";
+
         final String EXPECTED_ERROR =
-                "DecisionElement:Score"
-                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+                JsonValidationUtility.createIntegerRangeErrorMessage(
+                        TEST_VALUE,
+                        IdentityVerificationInfoResponseValidator.DECISION_ELEMENTS_SCORE_MIN_VALUE,
+                        IdentityVerificationInfoResponseValidator.DECISION_ELEMENTS_SCORE_MAX_VALUE,
+                        TEST_INTEGER_NAME);
 
         assertEquals(
                 TEST_VALUE,
@@ -2218,9 +2254,14 @@ public class IdentityVerificationInfoResponseValidatorTest {
         ValidationResult<List<String>> validationResult =
                 infoResponseValidator.validate(testIVResponse);
 
+        final String TEST_INTEGER_NAME = "DecisionElement:Score";
+
         final String EXPECTED_ERROR =
-                "DecisionElement:Score"
-                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+                JsonValidationUtility.createIntegerRangeErrorMessage(
+                        TEST_VALUE,
+                        IdentityVerificationInfoResponseValidator.DECISION_ELEMENTS_SCORE_MIN_VALUE,
+                        IdentityVerificationInfoResponseValidator.DECISION_ELEMENTS_SCORE_MAX_VALUE,
+                        TEST_INTEGER_NAME);
 
         assertEquals(
                 TEST_VALUE,
@@ -2523,10 +2564,12 @@ public class IdentityVerificationInfoResponseValidatorTest {
 
     @Test
     void clientPayloadDecisionElementsDecisionElementRuleScoreUnderMinFails() {
+        final int TEST_VALUE = -1;
+
         final Rule testRule = new Rule();
         testRule.setRuleName("ScoreUnderMinFail");
         testRule.setRuleId("");
-        testRule.setRuleScore(-1);
+        testRule.setRuleScore(TEST_VALUE);
         testRule.setRuleText("Test");
 
         testIVResponse
@@ -2538,9 +2581,29 @@ public class IdentityVerificationInfoResponseValidatorTest {
         ValidationResult<List<String>> validationResult =
                 infoResponseValidator.validate(testIVResponse);
 
+        final String TEST_INTEGER_NAME = "DecisionElement:Rules:Rule:Score";
+
         final String EXPECTED_ERROR =
-                "DecisionElement:Rules:Rule:Score"
-                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+                JsonValidationUtility.createIntegerRangeErrorMessage(
+                        TEST_VALUE,
+                        IdentityVerificationInfoResponseValidator
+                                .DECISION_ELEMENTS_RULE_NAME_SERVICE_LEVEL_SCORE_MIN,
+                        IdentityVerificationInfoResponseValidator
+                                .DECISION_ELEMENTS_RULE_NAME_SERVICE_LEVEL_SCORE_MAX,
+                        TEST_INTEGER_NAME);
+
+        assertEquals(
+                TEST_VALUE,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getRules()
+                        .get(0)
+                        .getRuleScore());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
 
         assertEquals(
                 1,
@@ -2565,10 +2628,11 @@ public class IdentityVerificationInfoResponseValidatorTest {
 
     @Test
     void clientPayloadDecisionElementsDecisionElementRuleScoreMinOK() {
+        final int TEST_VALUE = 0;
         final Rule testRule = new Rule();
         testRule.setRuleName("ScoreUnderMinFail");
         testRule.setRuleId("");
-        testRule.setRuleScore(0);
+        testRule.setRuleScore(TEST_VALUE);
         testRule.setRuleText("Test");
 
         testIVResponse
@@ -2589,23 +2653,25 @@ public class IdentityVerificationInfoResponseValidatorTest {
                         .getRules()
                         .size());
         assertEquals(
-                testRule,
+                TEST_VALUE,
                 testIVResponse
                         .getClientResponsePayload()
                         .getDecisionElements()
                         .get(0)
                         .getRules()
-                        .get(0));
+                        .get(0)
+                        .getRuleScore());
         assertEquals(0, validationResult.getError().size());
         assertTrue(validationResult.isValid());
     }
 
     @Test
     void clientPayloadDecisionElementsDecisionElementRuleScoreOverMaxFails() {
+        final int TEST_VALUE = 91;
         final Rule testRule = new Rule();
         testRule.setRuleName("ScoreUnderMinFail");
         testRule.setRuleId("");
-        testRule.setRuleScore(91);
+        testRule.setRuleScore(TEST_VALUE);
         testRule.setRuleText("Test");
 
         testIVResponse
@@ -2617,9 +2683,16 @@ public class IdentityVerificationInfoResponseValidatorTest {
         ValidationResult<List<String>> validationResult =
                 infoResponseValidator.validate(testIVResponse);
 
+        final String TEST_INTEGER_NAME = "DecisionElement:Rules:Rule:Score";
+
         final String EXPECTED_ERROR =
-                "DecisionElement:Rules:Rule:Score"
-                        + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+                JsonValidationUtility.createIntegerRangeErrorMessage(
+                        TEST_VALUE,
+                        IdentityVerificationInfoResponseValidator
+                                .DECISION_ELEMENTS_RULE_NAME_SERVICE_LEVEL_SCORE_MIN,
+                        IdentityVerificationInfoResponseValidator
+                                .DECISION_ELEMENTS_RULE_NAME_SERVICE_LEVEL_SCORE_MAX,
+                        TEST_INTEGER_NAME);
 
         assertEquals(
                 1,
@@ -2630,13 +2703,14 @@ public class IdentityVerificationInfoResponseValidatorTest {
                         .getRules()
                         .size());
         assertEquals(
-                testRule,
+                TEST_VALUE,
                 testIVResponse
                         .getClientResponsePayload()
                         .getDecisionElements()
                         .get(0)
                         .getRules()
-                        .get(0));
+                        .get(0)
+                        .getRuleScore());
         assertEquals(1, validationResult.getError().size());
         assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
         assertFalse(validationResult.isValid());
@@ -2644,10 +2718,11 @@ public class IdentityVerificationInfoResponseValidatorTest {
 
     @Test
     void clientPayloadDecisionElementsDecisionElementRuleScoreMaxOK() {
+        final int TEST_VALUE = 90;
         final Rule testRule = new Rule();
-        testRule.setRuleName("ScoreUnderMinFail");
+        testRule.setRuleName("RuleScoreMaxOK");
         testRule.setRuleId("");
-        testRule.setRuleScore(90);
+        testRule.setRuleScore(TEST_VALUE);
         testRule.setRuleText("Test");
 
         testIVResponse
@@ -2675,6 +2750,16 @@ public class IdentityVerificationInfoResponseValidatorTest {
                         .get(0)
                         .getRules()
                         .get(0));
+
+        assertEquals(
+                TEST_VALUE,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getRules()
+                        .get(0)
+                        .getRuleScore());
         assertEquals(0, validationResult.getError().size());
         assertTrue(validationResult.isValid());
     }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/PersonIdentityValidatorTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/PersonIdentityValidatorTest.java
@@ -1,0 +1,410 @@
+package uk.gov.di.ipv.cri.fraud.api.service;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
+import uk.gov.di.ipv.cri.fraud.api.domain.ValidationResult;
+import uk.gov.di.ipv.cri.fraud.api.util.JsonValidationUtility;
+import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PersonIdentityValidatorTest {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @Test
+    void testPersonIdentityNameCannotBeNull() {
+
+        final String TEST_STRING = null;
+
+        PersonIdentity personIdentity = TestDataCreator.createTestPersonIdentity();
+        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+
+        personIdentity.setFirstName(TEST_STRING);
+        personIdentity.setSurname(TEST_STRING);
+
+        ValidationResult<List<String>> validationResult =
+                personIdentityValidator.validate(personIdentity);
+
+        final String EXPECTED_ERROR_0 =
+                "FirstName" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+        final String EXPECTED_ERROR_1 =
+                "Surname" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+
+        LOGGER.info(validationResult.getError().toString());
+
+        assertEquals(TEST_STRING, personIdentity.getFirstName());
+        assertEquals(TEST_STRING, personIdentity.getSurname());
+        assertEquals(2, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR_0, validationResult.getError().get(0));
+        assertEquals(EXPECTED_ERROR_1, validationResult.getError().get(1));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void testPersonIdentityDOBCannotBeNull() {
+
+        final LocalDate TEST_LOCAL_DATE = null;
+
+        PersonIdentity personIdentity = TestDataCreator.createTestPersonIdentity();
+        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+
+        personIdentity.setDateOfBirth(TEST_LOCAL_DATE);
+
+        ValidationResult<List<String>> validationResult =
+                personIdentityValidator.validate(personIdentity);
+
+        final String EXPECTED_ERROR =
+                "DateOfBirth" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+
+        LOGGER.info(validationResult.getError().toString());
+
+        assertEquals(TEST_LOCAL_DATE, personIdentity.getDateOfBirth());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void testPersonIdentityAddressesCannotBeNull() {
+
+        final List<Address> TEST_ADDRESSES = null;
+
+        PersonIdentity personIdentity = TestDataCreator.createTestPersonIdentity();
+        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+
+        personIdentity.setAddresses(TEST_ADDRESSES);
+
+        ValidationResult<List<String>> validationResult =
+                personIdentityValidator.validate(personIdentity);
+
+        final String EXPECTED_ERROR =
+                "Addresses" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+
+        LOGGER.info(validationResult.getError().toString());
+
+        assertEquals(TEST_ADDRESSES, personIdentity.getAddresses());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void testPersonIdentityAddressesCannotBeEmpty() {
+
+        final List<Address> TEST_ADDRESSES = new ArrayList<>();
+
+        PersonIdentity personIdentity = TestDataCreator.createTestPersonIdentity();
+        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+
+        personIdentity.setAddresses(TEST_ADDRESSES);
+
+        ValidationResult<List<String>> validationResult =
+                personIdentityValidator.validate(personIdentity);
+
+        final String TEST_INTEGER_NAME = "Addresses";
+        final int TEST_VALUE = TEST_ADDRESSES.size();
+
+        final String EXPECTED_ERROR =
+                JsonValidationUtility.createIntegerRangeErrorMessage(
+                        TEST_VALUE,
+                        PersonIdentityValidator.MIN_SUPPORTED_ADDRESSES,
+                        PersonIdentityValidator.MAX_SUPPORTED_ADDRESSES,
+                        TEST_INTEGER_NAME);
+
+        LOGGER.info(validationResult.getError().toString());
+
+        assertEquals(TEST_ADDRESSES, personIdentity.getAddresses());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void testPersonIdentityTooManyAddressesFail() {
+
+        final int addressChainLength = PersonIdentityValidator.MAX_SUPPORTED_ADDRESSES;
+        final int additionalCurrentAddresses = 1;
+        final int additionalPreviousAddresses = 0;
+        final int TOTAL_ADDRESSES = addressChainLength + additionalCurrentAddresses;
+        final boolean shuffleAddresses = true;
+
+        PersonIdentity personIdentity =
+                TestDataCreator.createTestPersonIdentityMultipleAddresses(
+                        addressChainLength,
+                        additionalCurrentAddresses,
+                        additionalPreviousAddresses,
+                        shuffleAddresses);
+
+        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+
+        ValidationResult<List<String>> validationResult =
+                personIdentityValidator.validate(personIdentity);
+
+        final String EXPECTED_ERROR =
+                JsonValidationUtility.createIntegerRangeErrorMessage(
+                        TOTAL_ADDRESSES,
+                        PersonIdentityValidator.MIN_SUPPORTED_ADDRESSES,
+                        PersonIdentityValidator.MAX_SUPPORTED_ADDRESSES,
+                        "Addresses");
+
+        LOGGER.info(validationResult.getError().toString());
+
+        assertEquals(TOTAL_ADDRESSES, personIdentity.getAddresses().size());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void testPersonIdentityAddressesValidCurrentAddressIsOk() {
+
+        final Address TEST_CURRENT_ADDRESS = new Address();
+        TEST_CURRENT_ADDRESS.setValidFrom(LocalDate.now());
+
+        final List<Address> TEST_ADDRESSES = List.of(TEST_CURRENT_ADDRESS);
+
+        PersonIdentity personIdentity = TestDataCreator.createTestPersonIdentity();
+        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+
+        personIdentity.setAddresses(TEST_ADDRESSES);
+
+        ValidationResult<List<String>> validationResult =
+                personIdentityValidator.validate(personIdentity);
+
+        assertEquals(TEST_ADDRESSES, personIdentity.getAddresses());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void testPersonIdentityAddressesCurrentAddressNullDatesIsOk() {
+        // Edge case scenario : A current address where user does not know when exactly they moved
+        // in (ValidFrom null).
+
+        final Address TEST_CURRENT_ADDRESS = new Address();
+        TEST_CURRENT_ADDRESS.setValidFrom(null);
+        TEST_CURRENT_ADDRESS.setValidUntil(null);
+
+        final List<Address> TEST_ADDRESSES = List.of(TEST_CURRENT_ADDRESS);
+
+        PersonIdentity personIdentity = TestDataCreator.createTestPersonIdentity();
+        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+
+        personIdentity.setAddresses(TEST_ADDRESSES);
+
+        ValidationResult<List<String>> validationResult =
+                personIdentityValidator.validate(personIdentity);
+
+        assertEquals(TEST_ADDRESSES, personIdentity.getAddresses());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void testPersonIdentityAddressesCurrentAddressWithFutureDatesIsFail() {
+
+        final Address TEST_CURRENT_ADDRESS = new Address();
+        TEST_CURRENT_ADDRESS.setValidFrom(LocalDate.now().plusYears(1));
+        TEST_CURRENT_ADDRESS.setValidUntil(null);
+
+        final List<Address> TEST_ADDRESSES = List.of(TEST_CURRENT_ADDRESS);
+
+        PersonIdentity personIdentity = TestDataCreator.createTestPersonIdentity();
+        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+
+        personIdentity.setAddresses(TEST_ADDRESSES);
+
+        ValidationResult<List<String>> validationResult =
+                personIdentityValidator.validate(personIdentity);
+
+        final String EXPECTED_ERROR =
+                PersonIdentityValidator.createAddressCheckErrorMessage(1, 0, 0, 1);
+
+        LOGGER.info(validationResult.getError().toString());
+
+        assertEquals(TEST_ADDRESSES.size(), personIdentity.getAddresses().size());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void testPersonIdentityAddressesValidCurrentAndPreviousAddressIsOk() {
+
+        final Address TEST_CURRENT_ADDRESS = new Address();
+        TEST_CURRENT_ADDRESS.setValidFrom(LocalDate.of(1999, 12, 31));
+        TEST_CURRENT_ADDRESS.setValidUntil(null);
+
+        final Address TEST_PREVIOUS_ADDRESS = new Address();
+        TEST_PREVIOUS_ADDRESS.setValidFrom(null);
+        TEST_PREVIOUS_ADDRESS.setValidUntil(TEST_CURRENT_ADDRESS.getValidFrom());
+
+        final List<Address> TEST_ADDRESSES = List.of(TEST_CURRENT_ADDRESS, TEST_PREVIOUS_ADDRESS);
+
+        PersonIdentity personIdentity = TestDataCreator.createTestPersonIdentity();
+        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+
+        personIdentity.setAddresses(TEST_ADDRESSES);
+
+        ValidationResult<List<String>> validationResult =
+                personIdentityValidator.validate(personIdentity);
+
+        LOGGER.info(validationResult.getError().toString());
+
+        assertEquals(TEST_ADDRESSES, personIdentity.getAddresses());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void testPersonIdentityAddressesAValidCurrentAndPreviousAddressAreInReverseOrderIsOk() {
+
+        final Address TEST_CURRENT_ADDRESS = new Address();
+        TEST_CURRENT_ADDRESS.setValidFrom(LocalDate.now());
+
+        final Address TEST_PREVIOUS_ADDRESS = new Address();
+        TEST_PREVIOUS_ADDRESS.setValidUntil(TEST_CURRENT_ADDRESS.getValidFrom().minusDays(1));
+
+        final List<Address> TEST_ADDRESSES = List.of(TEST_PREVIOUS_ADDRESS, TEST_CURRENT_ADDRESS);
+
+        PersonIdentity personIdentity = TestDataCreator.createTestPersonIdentity();
+        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+
+        personIdentity.setAddresses(TEST_ADDRESSES);
+
+        ValidationResult<List<String>> validationResult =
+                personIdentityValidator.validate(personIdentity);
+
+        assertEquals(TEST_ADDRESSES, personIdentity.getAddresses());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void testPersonIdentityAddressesValidCurrentAndPreviousAddressOverlapIsOk() {
+        // Edge case scenario : A current address where user has moved out of the previous on the
+        // current date
+        // (CURRENT ValidFrom == PREVIOUS ValidUntil).
+
+        final Address TEST_CURRENT_ADDRESS = new Address();
+        TEST_CURRENT_ADDRESS.setValidFrom(LocalDate.now().atTime(0, 0).toLocalDate());
+
+        final Address TEST_PREVIOUS_ADDRESS = new Address();
+        TEST_PREVIOUS_ADDRESS.setValidUntil(TEST_CURRENT_ADDRESS.getValidFrom());
+
+        final List<Address> TEST_ADDRESSES = List.of(TEST_CURRENT_ADDRESS, TEST_PREVIOUS_ADDRESS);
+
+        PersonIdentity personIdentity = TestDataCreator.createTestPersonIdentity();
+        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+
+        personIdentity.setAddresses(TEST_ADDRESSES);
+
+        ValidationResult<List<String>> validationResult =
+                personIdentityValidator.validate(personIdentity);
+
+        assertEquals(TEST_ADDRESSES, personIdentity.getAddresses());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void testPersonIdentityAddressesMultipleCurrentAddressesIsOk() {
+
+        final Address TEST_CURRENT_ADDRESS_1 = new Address();
+        TEST_CURRENT_ADDRESS_1.setValidFrom(LocalDate.now());
+        TEST_CURRENT_ADDRESS_1.setValidUntil(null);
+
+        final Address TEST_CURRENT_ADDRESS_2 = new Address();
+        TEST_CURRENT_ADDRESS_2.setValidFrom(LocalDate.now());
+        TEST_CURRENT_ADDRESS_2.setValidUntil(null);
+
+        final List<Address> TEST_ADDRESSES =
+                List.of(TEST_CURRENT_ADDRESS_1, TEST_CURRENT_ADDRESS_2);
+
+        PersonIdentity personIdentity = TestDataCreator.createTestPersonIdentity();
+        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+
+        personIdentity.setAddresses(TEST_ADDRESSES);
+
+        ValidationResult<List<String>> validationResult =
+                personIdentityValidator.validate(personIdentity);
+
+        assertEquals(TEST_ADDRESSES, personIdentity.getAddresses());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    void testPersonIdentityAddressesManyPreviousAddressesFail() {
+
+        final int addressChainLength = 0;
+        final int additionalCurrentAddresses = 0;
+        final int additionalPreviousAddresses = 2;
+        final int TOTAL_ADDRESSES =
+                addressChainLength + additionalCurrentAddresses + additionalPreviousAddresses;
+        final boolean shuffleAddresses = true;
+
+        PersonIdentity personIdentity =
+                TestDataCreator.createTestPersonIdentityMultipleAddresses(
+                        addressChainLength,
+                        additionalCurrentAddresses,
+                        additionalPreviousAddresses,
+                        shuffleAddresses);
+
+        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+
+        ValidationResult<List<String>> validationResult =
+                personIdentityValidator.validate(personIdentity);
+
+        final String EXPECTED_ERROR =
+                PersonIdentityValidator.createAddressCheckErrorMessage(
+                        TOTAL_ADDRESSES,
+                        additionalCurrentAddresses,
+                        additionalPreviousAddresses,
+                        0);
+
+        LOGGER.info(validationResult.getError().toString());
+
+        assertEquals(TOTAL_ADDRESSES, personIdentity.getAddresses().size());
+        assertEquals(1, validationResult.getError().size());
+        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
+        assertFalse(validationResult.isValid());
+    }
+
+    @Test
+    void testPersonIdentityAddressesManyValidCurrentAndValidPreviousAddressesOutOfOrderIsOK() {
+
+        final int addressChainLength = 10;
+        final int additionalCurrentAddresses = 5;
+        final int additionalPreviousAddresses = 5;
+        final int TOTAL_ADDRESSES =
+                addressChainLength + additionalCurrentAddresses + additionalPreviousAddresses;
+        final boolean shuffleAddresses = true;
+
+        PersonIdentity personIdentity =
+                TestDataCreator.createTestPersonIdentityMultipleAddresses(
+                        addressChainLength,
+                        additionalCurrentAddresses,
+                        additionalPreviousAddresses,
+                        shuffleAddresses);
+
+        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+
+        ValidationResult<List<String>> validationResult =
+                personIdentityValidator.validate(personIdentity);
+
+        assertEquals(TOTAL_ADDRESSES, personIdentity.getAddresses().size());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+}

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/JsonValidationUtilityTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/JsonValidationUtilityTest.java
@@ -9,8 +9,10 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JsonValidationUtilityTest {
 
@@ -444,7 +446,8 @@ class JsonValidationUtilityTest {
                         validationErrors);
 
         final String EXPECTED_ERROR =
-                TEST_INTEGER_NAME + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+                JsonValidationUtility.createIntegerRangeErrorMessage(
+                        TEST_INT, TEST_INT_RANGE_MIN, TEST_INT_RANGE_MAX, TEST_INTEGER_NAME);
 
         assertEquals(1, validationErrors.size());
         assertEquals(EXPECTED_ERROR, validationErrors.get(0));
@@ -464,7 +467,8 @@ class JsonValidationUtilityTest {
                         validationErrors);
 
         final String EXPECTED_ERROR =
-                TEST_INTEGER_NAME + JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_SUFFIX;
+                JsonValidationUtility.createIntegerRangeErrorMessage(
+                        TEST_INT, TEST_INT_RANGE_MIN, TEST_INT_RANGE_MAX, TEST_INTEGER_NAME);
 
         assertEquals(1, validationErrors.size());
         assertEquals(EXPECTED_ERROR, validationErrors.get(0));


### PR DESCRIPTION
## Proposed changes

### What changed

PersonIdentityValidator has been updated to check addresses are valid.

Validation Errors will be logged for -
- There not being an address that evaluates as a CURRENT AddressType.
- There being only PREVIOUS AddressTypes.
- There being no valid addressTypes.
- Any address AddressType is evaluated as null.
- Address counts 0 or >32

Range validation message changed to a string format and the range checked included.

Logging added for number of address and types.

### Why did it change

PersonIdentityValidator
Address information was not checked prior to conversion into the Experian request format. Addresses are not required to be in-order, with an artificial limit of 32.
A addressTypes are counted, with 1 CURRENT address required to pass validation. The absence of CURRENT address or presence of null addressType will fail validation.

Validation Errors
Logged as these are reasons a user has failed validation and a fraud check not performed.

Range validation message
Including range checked is more informative.

The number of address found and the types evaluated will aid tracking any errors.

### Issue tracking

- [LIME-61](https://govukverify.atlassian.net/browse/LIME-61) formerly [KBV-771](https://govukverify.atlassian.net/browse/KBV-771) 
- Depends on for addressType evaluation https://github.com/alphagov/di-ipv-cri-lib/pull/41
