### PR TITLE
KBV-767 Improve performance of Fraud API CRI

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -68,7 +68,9 @@ Globals:
     Runtime: java11
     AutoPublishAlias: live
     Tracing: Active
-    MemorySize: 2048
+    MemorySize: !FindInMap [MemorySizeMapping, Environment, !Ref 'Environment']
+    Architectures:
+      - arm64
     Environment:
       Variables:
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
@@ -81,6 +83,14 @@ Globals:
       - !Ref AWS::NoValue
 
 Mappings:
+
+  MemorySizeMapping:
+    Environment:
+      dev: 512
+      build: 1024
+      staging: 1024
+      integration: 1024
+      production: 2048
 
   SessionTtlMapping:
     Environment:


### PR DESCRIPTION
## Proposed changes

### What changed

Changed architecture to arm64 and set memory values to align with other CRIs for each environment.

### Why did it change

Testing for other CRI's and now shown for Fraud CRI demonstrated a small improvement in cold starts using arm64 architecture and a much larger improvement for cold starts with increased memory settings.

### Issue tracking

- [KBV-767](https://govukverify.atlassian.net/browse/KBV-767)