### PR TITLE
KBV-813 Use AuditEventContext when sending AuditEvent's.

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
@@ -3,8 +3,10 @@ package uk.gov.di.ipv.cri.fraud.api.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.common.library.domain.AuditEventContext;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.service.AuditService;
 import uk.gov.di.ipv.cri.fraud.api.domain.FraudCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.domain.IdentityVerificationResult;
@@ -14,6 +16,7 @@ import uk.gov.di.ipv.cri.fraud.api.gateway.ThirdPartyFraudGateway;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class IdentityVerificationService {
@@ -45,7 +48,10 @@ public class IdentityVerificationService {
         this.auditService = auditService;
     }
 
-    public IdentityVerificationResult verifyIdentity(PersonIdentity personIdentity) {
+    public IdentityVerificationResult verifyIdentity(
+            PersonIdentity personIdentity,
+            SessionItem sessionItem,
+            Map<String, String> requestHeaders) {
         IdentityVerificationResult result = new IdentityVerificationResult();
         try {
             LOGGER.info("Validating identity...");
@@ -88,6 +94,7 @@ public class IdentityVerificationService {
                             identityCheckScore);
                     auditService.sendAuditEvent(
                             AuditEventType.THIRD_PARTY_REQUEST_ENDED,
+                            new AuditEventContext(requestHeaders, sessionItem),
                             new TPREFraudAuditExtension(
                                     List.of(fraudCheckResult.getThirdPartyFraudCodes())));
                 } else {

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.service.AuditService;
 import uk.gov.di.ipv.cri.fraud.api.domain.FraudCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.domain.IdentityVerificationResult;
@@ -15,6 +16,7 @@ import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -30,6 +32,8 @@ class IdentityVerificationServiceTest {
     @Mock private ContraindicationMapper mockContraindicationMapper;
     @Mock private IdentityScoreCalaculator identityScoreCalaculator;
     @Mock private AuditService mockAuditService;
+    @Mock private SessionItem sessionItem;
+    @Mock private Map<String, String> requestHeaders;
 
     private IdentityVerificationService identityVerificationService;
 
@@ -61,7 +65,8 @@ class IdentityVerificationServiceTest {
                 .thenReturn(mappedFraudCodes);
 
         IdentityVerificationResult result =
-                this.identityVerificationService.verifyIdentity(testPersonIdentity);
+                this.identityVerificationService.verifyIdentity(
+                        testPersonIdentity, sessionItem, requestHeaders);
 
         assertNotNull(result);
         assertEquals(mappedFraudCodes[0], result.getContraIndicators()[0]);
@@ -78,7 +83,8 @@ class IdentityVerificationServiceTest {
                 .thenReturn(new ValidationResult<>(false, validationErrors));
 
         IdentityVerificationResult result =
-                this.identityVerificationService.verifyIdentity(testPersonIdentity);
+                this.identityVerificationService.verifyIdentity(
+                        testPersonIdentity, sessionItem, requestHeaders);
 
         assertNotNull(result);
         assertNull(result.getContraIndicators());
@@ -95,7 +101,8 @@ class IdentityVerificationServiceTest {
         when(mockThirdPartyGateway.performFraudCheck(testPersonIdentity)).thenReturn(null);
 
         IdentityVerificationResult result =
-                this.identityVerificationService.verifyIdentity(testPersonIdentity);
+                this.identityVerificationService.verifyIdentity(
+                        testPersonIdentity, sessionItem, requestHeaders);
 
         assertNotNull(result);
         assertFalse(result.isSuccess());

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/IssueCredentialHandler.java
@@ -18,10 +18,15 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.metrics.Metrics;
+import uk.gov.di.ipv.cri.common.library.domain.AuditEventContext;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventType;
 import uk.gov.di.ipv.cri.common.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.common.library.exception.SqsException;
-import uk.gov.di.ipv.cri.common.library.service.*;
+import uk.gov.di.ipv.cri.common.library.service.AuditEventFactory;
+import uk.gov.di.ipv.cri.common.library.service.AuditService;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.service.PersonIdentityService;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.fraud.api.exception.CredentialRequestException;
@@ -112,6 +117,7 @@ public class IssueCredentialHandler
                             sessionItem.getSubject(), fraudResult, personIdentityDetailed);
             auditService.sendAuditEvent(
                     AuditEventType.VC_ISSUED,
+                    new AuditEventContext(input.getHeaders(), sessionItem),
                     IssueCredentialFraudAuditExtensionUtil.generateVCISSFraudAuditExtension(
                             verifiableCredentialService.getVerifiableCredentialIssuer(),
                             List.of(fraudResult)));


### PR DESCRIPTION
## Proposed changes

### What changed

AuditEvents are sent using an AuditEventContext.

### Why did it change

FraudAPI was updated to use the latest AuditService changes, but message sending was not updated to include an AuditEventContext. This meant although events where successfully sent they where now in the wrong format.

### Issue tracking

- [KBV-813](https://govukverify.atlassian.net/browse/KBV-813)