### PR TITLE
LIME-25: Updating build to use acceptance repo rather than home

### DIFF
--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -69,7 +69,7 @@ jobs:
           ECR_REPOSITORY_STAGING: ${{ secrets.ECR_REPOSITORY_STAGING }}
           IMAGE_TAG: latest
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG .
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG acceptance-tests
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG
           cosign sign --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG


### PR DESCRIPTION
## Proposed changes

### What changed

Update to push test image to staging

### Why did it change

To unblock the deployment pipeline
