### PR TITLE
LIME-11 - Implementing PEP request

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationResponseMapper.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationResponseMapper.java
@@ -5,11 +5,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.fraud.api.domain.FraudCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.domain.ValidationResult;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.DecisionElement;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.IdentityVerificationResponse;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.ResponseHeader;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.ResponseType;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.Rule;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.*;
 import uk.gov.di.ipv.cri.fraud.api.service.IdentityVerificationInfoResponseValidator;
 
 import java.util.ArrayList;
@@ -42,12 +38,65 @@ public class IdentityVerificationResponseMapper {
         }
     }
 
+    FraudCheckResult mapPEPResponse(PEPResponse response) {
+        ResponseType responseType = response.getResponseHeader().getResponseType();
+
+        switch (responseType) {
+            case INFO:
+                return mapResponse(response, new IdentityVerificationInfoResponseValidator());
+            case ERROR:
+            case WARN:
+            case WARNING:
+                return mapErrorResponse(response.getResponseHeader());
+            default:
+                throw new IllegalArgumentException(
+                        "Unmapped response type encountered: " + responseType);
+        }
+    }
+
     private FraudCheckResult mapResponse(
             IdentityVerificationResponse response,
             IdentityVerificationInfoResponseValidator infoResponseValidator) {
         FraudCheckResult fraudCheckResult = new FraudCheckResult();
 
         ValidationResult<List<String>> validationResult = infoResponseValidator.validate(response);
+
+        if (validationResult.isValid()) {
+            fraudCheckResult.setExecutedSuccessfully(true);
+
+            List<DecisionElement> decisionElements =
+                    response.getClientResponsePayload().getDecisionElements();
+
+            List<String> fraudCodes = new ArrayList<>();
+
+            for (DecisionElement decisionElement : decisionElements) {
+                decisionElement.getRules().stream()
+                        .map(Rule::getRuleId)
+                        .filter(StringUtils::isNotBlank)
+                        .sequential()
+                        .collect(Collectors.toCollection(() -> fraudCodes));
+            }
+
+            fraudCheckResult.setThirdPartyFraudCodes(
+                    fraudCodes.toArray(fraudCodes.toArray(String[]::new)));
+        } else {
+            fraudCheckResult.setExecutedSuccessfully(false);
+            fraudCheckResult.setErrorMessage(IV_INFO_RESPONSE_VALIDATION_FAILED_MSG);
+
+            LOGGER.error(
+                    () -> (IV_INFO_RESPONSE_VALIDATION_FAILED_MSG + validationResult.getError()));
+        }
+        fraudCheckResult.setTransactionId(response.getResponseHeader().getExpRequestId());
+        return fraudCheckResult;
+    }
+
+    // TODO: Will need to be reviewed in LIME-37
+    private FraudCheckResult mapResponse(
+            PEPResponse response, IdentityVerificationInfoResponseValidator infoResponseValidator) {
+        FraudCheckResult fraudCheckResult = new FraudCheckResult();
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validatePEP(response);
 
         if (validationResult.isValid()) {
             fraudCheckResult.setExecutedSuccessfully(true);

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/request/PEPRequest.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/request/PEPRequest.java
@@ -1,0 +1,3 @@
+package uk.gov.di.ipv.cri.fraud.api.gateway.dto.request;
+
+public class PEPRequest extends IdentityVerificationRequest {}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/PEPResponse.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/PEPResponse.java
@@ -1,0 +1,8 @@
+package uk.gov.di.ipv.cri.fraud.api.gateway.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonIgnoreProperties(value = "originalRequestData")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PEPResponse extends IdentityVerificationResponse {}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationService.java
@@ -46,6 +46,7 @@ public class ConfigurationService {
     private final String fraudResultTableName;
     private final String contraindicationMappings;
     private final String parameterPrefix;
+    private final String pepEnabled;
 
     public ConfigurationService(
             SecretsProvider secretsProvider, ParamProvider paramProvider, String env) {
@@ -56,16 +57,34 @@ public class ConfigurationService {
             throw new IllegalArgumentException("env must be specified");
         }
 
+        //      *********************************Private
+        // Paramaters***********************************************
+
+        this.parameterPrefix = System.getenv("AWS_STACK_NAME");
         this.tenantId = paramProvider.get(String.format(KEY_FORMAT, env, "thirdPartyApiTenantId"));
         this.endpointUrl =
                 paramProvider.get(String.format(KEY_FORMAT, env, "thirdPartyApiEndpointUrl"));
         this.hmacKey = secretsProvider.get(String.format(KEY_FORMAT, env, "thirdPartyApiHmacKey"));
         this.thirdPartyId = paramProvider.get(String.format(KEY_FORMAT, env, "thirdPartyId"));
 
-        this.parameterPrefix = System.getenv("AWS_STACK_NAME");
         this.contraindicationMappings =
                 paramProvider.get(getParameterName("contraindicationMappings"));
         this.fraudResultTableName = paramProvider.get(getParameterName("FraudTableName"));
+
+        //      *********************************Feature
+        // toggles***********************************************
+
+        String pepEnabledFlag;
+        try {
+            // pepEnabled flag will need to be manually added as a parameter in AWS
+            pepEnabledFlag = paramProvider.get(getParameterName("pepEnabled"));
+        } catch (Exception e) {
+            pepEnabledFlag = "false";
+        }
+        this.pepEnabled = pepEnabledFlag;
+
+        //
+        // *********************************Secret***********************************************
 
         KeyStoreParams keyStoreParams =
                 secretsProvider
@@ -108,6 +127,10 @@ public class ConfigurationService {
 
     public String getContraindicationMappings() {
         return contraindicationMappings;
+    }
+
+    public Boolean getPepEnabled() {
+        return Boolean.valueOf(pepEnabled);
     }
 
     public String getParameterName(String parameterName) {

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidator.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidator.java
@@ -80,6 +80,25 @@ public class IdentityVerificationInfoResponseValidator {
         return new ValidationResult<>(validationErrors.isEmpty(), validationErrors);
     }
 
+    // TODO: will need to be reviewed in LIME-37
+
+    public ValidationResult<List<String>> validatePEP(PEPResponse response) {
+
+        final List<String> validationErrors = new ArrayList<>();
+
+        if (response != null) {
+            validateIdentityVerificationResponseHeader(
+                    response.getResponseHeader(), validationErrors);
+
+            validateIdentityVerificationResponseClientResponsePayload(
+                    response.getClientResponsePayload(), validationErrors);
+        } else {
+            validationErrors.add(NULL_RESPONSE_ERROR_MESSAGE);
+        }
+
+        return new ValidationResult<>(validationErrors.isEmpty(), validationErrors);
+    }
+
     private void validateIdentityVerificationResponseHeader(
             ResponseHeader header, final List<String> validationErrors) {
         if (header == null) {

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactory.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactory.java
@@ -97,7 +97,8 @@ public class ServiceFactory {
                 this.personIdentityValidator,
                 this.contraindicationMapper,
                 identityScoreCalaculator,
-                auditService);
+                auditService,
+                configurationService);
     }
 
     public AuditService getAuditService() {

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayTest.java
@@ -112,7 +112,7 @@ class ThirdPartyFraudGatewayTest {
                 .thenReturn(testFraudCheckResult);
 
         FraudCheckResult actualFraudCheckResult =
-                thirdPartyFraudGateway.performFraudCheck(personIdentity);
+                thirdPartyFraudGateway.performFraudCheck(personIdentity, false);
 
         verify(mockRequestMapper).mapPersonIdentity(personIdentity);
         verify(mockObjectMapper).writeValueAsString(testApiRequest);
@@ -152,7 +152,7 @@ class ThirdPartyFraudGatewayTest {
                 .thenReturn(createMockApiResponse(MOCK_HTTP_STATUS_CODE));
 
         FraudCheckResult actualFraudCheckResult =
-                thirdPartyFraudGateway.performFraudCheck(personIdentity);
+                thirdPartyFraudGateway.performFraudCheck(personIdentity, false);
 
         final String EXPECTED_ERROR =
                 ThirdPartyFraudGateway.HTTP_300_REDIRECT_MESSAGE + MOCK_HTTP_STATUS_CODE;
@@ -197,7 +197,7 @@ class ThirdPartyFraudGatewayTest {
                 .thenReturn(createMockApiResponse(MOCK_HTTP_STATUS_CODE));
 
         FraudCheckResult actualFraudCheckResult =
-                thirdPartyFraudGateway.performFraudCheck(personIdentity);
+                thirdPartyFraudGateway.performFraudCheck(personIdentity, false);
 
         final String EXPECTED_ERROR =
                 ThirdPartyFraudGateway.HTTP_400_CLIENT_REQUEST_ERROR + MOCK_HTTP_STATUS_CODE;
@@ -242,7 +242,7 @@ class ThirdPartyFraudGatewayTest {
                 .thenReturn(createMockApiResponse(MOCK_HTTP_STATUS_CODE));
 
         FraudCheckResult actualFraudCheckResult =
-                thirdPartyFraudGateway.performFraudCheck(personIdentity);
+                thirdPartyFraudGateway.performFraudCheck(personIdentity, false);
 
         final String EXPECTED_ERROR =
                 ThirdPartyFraudGateway.HTTP_500_SERVER_ERROR + MOCK_HTTP_STATUS_CODE;
@@ -289,7 +289,7 @@ class ThirdPartyFraudGatewayTest {
                 .thenReturn(createMockApiResponse(MOCK_HTTP_STATUS_CODE));
 
         FraudCheckResult actualFraudCheckResult =
-                thirdPartyFraudGateway.performFraudCheck(personIdentity);
+                thirdPartyFraudGateway.performFraudCheck(personIdentity, false);
 
         final String EXPECTED_ERROR =
                 ThirdPartyFraudGateway.HTTP_UNHANDLED_ERROR + MOCK_HTTP_STATUS_CODE;
@@ -341,7 +341,7 @@ class ThirdPartyFraudGatewayTest {
                 .thenReturn(testFraudCheckResult);
 
         FraudCheckResult actualFraudCheckResult =
-                thirdPartyFraudGateway.performFraudCheck(personIdentity);
+                thirdPartyFraudGateway.performFraudCheck(personIdentity, false);
 
         verify(mockRequestMapper).mapPersonIdentity(personIdentity);
         verify(mockObjectMapper).writeValueAsString(testApiRequest);
@@ -392,7 +392,7 @@ class ThirdPartyFraudGatewayTest {
                 .thenReturn(testFraudCheckResult);
 
         FraudCheckResult actualFraudCheckResult =
-                thirdPartyFraudGateway.performFraudCheck(personIdentity);
+                thirdPartyFraudGateway.performFraudCheck(personIdentity, false);
 
         verify(mockRequestMapper).mapPersonIdentity(personIdentity);
         verify(mockObjectMapper).writeValueAsString(testApiRequest);
@@ -441,7 +441,7 @@ class ThirdPartyFraudGatewayTest {
                 .thenReturn(createMockApiResponse(MOCK_HTTP_STATUS_CODE)); // Retry 7 Fail
 
         FraudCheckResult actualFraudCheckResult =
-                thirdPartyFraudGateway.performFraudCheck(personIdentity);
+                thirdPartyFraudGateway.performFraudCheck(personIdentity, false);
 
         final String EXPECTED_ERROR =
                 ThirdPartyFraudGateway.HTTP_500_SERVER_ERROR + MOCK_HTTP_STATUS_CODE;

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
@@ -34,6 +34,7 @@ class IdentityVerificationServiceTest {
     @Mock private AuditService mockAuditService;
     @Mock private SessionItem sessionItem;
     @Mock private Map<String, String> requestHeaders;
+    @Mock private ConfigurationService configurationService;
 
     private IdentityVerificationService identityVerificationService;
 
@@ -45,7 +46,8 @@ class IdentityVerificationServiceTest {
                         personIdentityValidator,
                         mockContraindicationMapper,
                         identityScoreCalaculator,
-                        mockAuditService);
+                        mockAuditService,
+                        configurationService);
     }
 
     @Test
@@ -59,7 +61,7 @@ class IdentityVerificationServiceTest {
         testFraudCheckResult.setThirdPartyFraudCodes(thirdPartyFraudCodes);
         when(personIdentityValidator.validate(testPersonIdentity))
                 .thenReturn(ValidationResult.createValidResult());
-        when(mockThirdPartyGateway.performFraudCheck(testPersonIdentity))
+        when(mockThirdPartyGateway.performFraudCheck(testPersonIdentity, false))
                 .thenReturn(testFraudCheckResult);
         when(mockContraindicationMapper.mapThirdPartyFraudCodes(thirdPartyFraudCodes))
                 .thenReturn(mappedFraudCodes);
@@ -71,7 +73,7 @@ class IdentityVerificationServiceTest {
         assertNotNull(result);
         assertEquals(mappedFraudCodes[0], result.getContraIndicators()[0]);
         verify(personIdentityValidator).validate(testPersonIdentity);
-        verify(mockThirdPartyGateway).performFraudCheck(testPersonIdentity);
+        verify(mockThirdPartyGateway).performFraudCheck(testPersonIdentity, false);
         verify(mockContraindicationMapper).mapThirdPartyFraudCodes(thirdPartyFraudCodes);
     }
 
@@ -98,7 +100,7 @@ class IdentityVerificationServiceTest {
         PersonIdentity testPersonIdentity = TestDataCreator.createTestPersonIdentity();
         when(personIdentityValidator.validate(testPersonIdentity))
                 .thenReturn(ValidationResult.createValidResult());
-        when(mockThirdPartyGateway.performFraudCheck(testPersonIdentity)).thenReturn(null);
+        when(mockThirdPartyGateway.performFraudCheck(testPersonIdentity, false)).thenReturn(null);
 
         IdentityVerificationResult result =
                 this.identityVerificationService.verifyIdentity(


### PR DESCRIPTION
## Proposed changes

- Added "pepEnabled" flag to configuration service to be used in turning PEP check on and off
- Updated ThirdPartyFraudGateway to have an additional request for PEPcheck should the pepEnabled flag be true
- Added PEPRequest and PEPResponse classes (Same as IdentityVerificationRequest/Response for now) Which will need to be reviewed in LIME-37

### Why did it change

To implament the PEP request into our flow