### PR TITLE
Lime 43 - Updating IdentityScoreCalculator

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculator.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculator.java
@@ -3,15 +3,15 @@ package uk.gov.di.ipv.cri.fraud.api.service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class IdentityScoreCalaculator {
+public class IdentityScoreCalculator {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    public IdentityScoreCalaculator() {}
-
     public int calculateIdentityScore(
-            boolean thirdPartyFraudCheckSuccess, String[] contraIndicators) {
-        if (thirdPartyFraudCheckSuccess) {
+            boolean thirdPartyFraudCheckSuccess, boolean thirdPartyPepCheckSuccess) {
+        if (thirdPartyFraudCheckSuccess && thirdPartyPepCheckSuccess) {
+            return 2;
+        } else if (thirdPartyFraudCheckSuccess && !thirdPartyPepCheckSuccess) {
             return 1;
         } else {
             return 0;

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidator.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidator.java
@@ -34,12 +34,12 @@ public class IdentityVerificationInfoResponseValidator {
     public static final int DECISION_ELEMENTS_SERVICE_NAME_MAX_LEN = 40;
     public static final int DECISION_ELEMENTS_DECISION_MAX_LEN = 20;
     public static final int DECISION_ELEMENTS_SCORE_MIN_VALUE = 0;
-    public static final int DECISION_ELEMENTS_SCORE_MAX_VALUE = 90;
+    public static final int DECISION_ELEMENTS_SCORE_MAX_VALUE = 260;
     public static final int DECISION_ELEMENTS_DECISION_TEXT_MAX_LEN = 20;
     public static final int DECISION_ELEMENTS_DECISION_REASON_MAX_LEN = 100;
     public static final int DECISION_ELEMENTS_APP_REF_MAX_LEN = 100;
     public static final int DECISION_ELEMENTS_RULE_NAME_SERVICE_LEVEL_SCORE_MIN = 0;
-    public static final int DECISION_ELEMENTS_RULE_NAME_SERVICE_LEVEL_SCORE_MAX = 90;
+    public static final int DECISION_ELEMENTS_RULE_NAME_SERVICE_LEVEL_SCORE_MAX = 260;
     public static final int DECISION_ELEMENTS_WARNING_RESPONSE_CODE_MAX_LEN = 40;
     public static final int DECISION_ELEMENTS_WARNING_RESPONSE_MESSAGE_MAX_LEN = 300;
 

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactory.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactory.java
@@ -88,12 +88,12 @@ public class ServiceFactory {
                         new HmacGenerator(this.configurationService.getHmacKey()),
                         this.configurationService.getEndpointUrl());
 
-        final IdentityScoreCalaculator identityScoreCalaculator = new IdentityScoreCalaculator();
+        final IdentityScoreCalculator identityScoreCalculator = new IdentityScoreCalculator();
         return new IdentityVerificationService(
                 thirdPartyGateway,
                 this.personIdentityValidator,
                 this.contraindicationMapper,
-                identityScoreCalaculator,
+                identityScoreCalculator,
                 auditService,
                 configurationService);
     }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
@@ -2248,7 +2248,7 @@ public class IdentityVerificationInfoResponseValidatorTest {
 
     @Test
     void clientPayloadDecisionElementsDecisionElementScoreOverMaxFails() {
-        final int TEST_VALUE = 91;
+        final int TEST_VALUE = 261;
         testIVResponse.getClientResponsePayload().getDecisionElements().get(0).setScore(TEST_VALUE);
 
         ValidationResult<List<String>> validationResult =
@@ -2667,7 +2667,7 @@ public class IdentityVerificationInfoResponseValidatorTest {
 
     @Test
     void clientPayloadDecisionElementsDecisionElementRuleScoreOverMaxFails() {
-        final int TEST_VALUE = 91;
+        final int TEST_VALUE = 261;
         final Rule testRule = new Rule();
         testRule.setRuleName("ScoreUnderMinFail");
         testRule.setRuleId("");
@@ -2718,7 +2718,7 @@ public class IdentityVerificationInfoResponseValidatorTest {
 
     @Test
     void clientPayloadDecisionElementsDecisionElementRuleScoreMaxOK() {
-        final int TEST_VALUE = 90;
+        final int TEST_VALUE = 260;
         final Rule testRule = new Rule();
         testRule.setRuleName("RuleScoreMaxOK");
         testRule.setRuleId("");

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
@@ -30,7 +30,7 @@ class IdentityVerificationServiceTest {
     @Mock private ThirdPartyFraudGateway mockThirdPartyGateway;
     @Mock private PersonIdentityValidator personIdentityValidator;
     @Mock private ContraindicationMapper mockContraindicationMapper;
-    @Mock private IdentityScoreCalaculator identityScoreCalaculator;
+    @Mock private IdentityScoreCalculator identityScoreCalculator;
     @Mock private AuditService mockAuditService;
     @Mock private SessionItem sessionItem;
     @Mock private Map<String, String> requestHeaders;
@@ -45,7 +45,7 @@ class IdentityVerificationServiceTest {
                         mockThirdPartyGateway,
                         personIdentityValidator,
                         mockContraindicationMapper,
-                        identityScoreCalaculator,
+                        identityScoreCalculator,
                         mockAuditService,
                         configurationService);
     }


### PR DESCRIPTION
### What changed
Updated Identity score Calculator to give a score of 2 if pep check and fraud check are successful

### Why did it change
To allow for a score of 2 for users who have completed a pep check