### PR TITLE
LIME-37 - Updating max fraud score value in validator

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidator.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidator.java
@@ -34,12 +34,12 @@ public class IdentityVerificationInfoResponseValidator {
     public static final int DECISION_ELEMENTS_SERVICE_NAME_MAX_LEN = 40;
     public static final int DECISION_ELEMENTS_DECISION_MAX_LEN = 20;
     public static final int DECISION_ELEMENTS_SCORE_MIN_VALUE = 0;
-    public static final int DECISION_ELEMENTS_SCORE_MAX_VALUE = 260;
+    public static final int DECISION_ELEMENTS_SCORE_MAX_VALUE = 99999;
     public static final int DECISION_ELEMENTS_DECISION_TEXT_MAX_LEN = 20;
     public static final int DECISION_ELEMENTS_DECISION_REASON_MAX_LEN = 100;
     public static final int DECISION_ELEMENTS_APP_REF_MAX_LEN = 100;
     public static final int DECISION_ELEMENTS_RULE_NAME_SERVICE_LEVEL_SCORE_MIN = 0;
-    public static final int DECISION_ELEMENTS_RULE_NAME_SERVICE_LEVEL_SCORE_MAX = 260;
+    public static final int DECISION_ELEMENTS_RULE_NAME_SERVICE_LEVEL_SCORE_MAX = 99999;
     public static final int DECISION_ELEMENTS_WARNING_RESPONSE_CODE_MAX_LEN = 40;
     public static final int DECISION_ELEMENTS_WARNING_RESPONSE_MESSAGE_MAX_LEN = 300;
 

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
@@ -2248,7 +2248,7 @@ public class IdentityVerificationInfoResponseValidatorTest {
 
     @Test
     void clientPayloadDecisionElementsDecisionElementScoreOverMaxFails() {
-        final int TEST_VALUE = 261;
+        final int TEST_VALUE = 100000;
         testIVResponse.getClientResponsePayload().getDecisionElements().get(0).setScore(TEST_VALUE);
 
         ValidationResult<List<String>> validationResult =
@@ -2667,7 +2667,7 @@ public class IdentityVerificationInfoResponseValidatorTest {
 
     @Test
     void clientPayloadDecisionElementsDecisionElementRuleScoreOverMaxFails() {
-        final int TEST_VALUE = 261;
+        final int TEST_VALUE = 100000;
         final Rule testRule = new Rule();
         testRule.setRuleName("ScoreUnderMinFail");
         testRule.setRuleId("");
@@ -2718,7 +2718,7 @@ public class IdentityVerificationInfoResponseValidatorTest {
 
     @Test
     void clientPayloadDecisionElementsDecisionElementRuleScoreMaxOK() {
-        final int TEST_VALUE = 260;
+        final int TEST_VALUE = 99999;
         final Rule testRule = new Rule();
         testRule.setRuleName("RuleScoreMaxOK");
         testRule.setRuleId("");


### PR DESCRIPTION
What changed
Changed Max value for score in the IdentityVerificationInfoResponseValidator.java

Why did it change
To allow for the updated fraud score range in fraud check caused by the addition of pep Check