### PR TITLE
LIME-34: Removed the pep transactionId from the VC until we update the VC

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
@@ -125,10 +125,12 @@ public class IdentityVerificationService {
                             pepIdentityCheckScore != null
                                     ? pepIdentityCheckScore
                                     : fraudIdentityCheckScore;
-                    String transactionId =
-                            pepTransactionId != null
-                                    ? fraudTransactionId + "|" + pepTransactionId
-                                    : fraudTransactionId;
+                    String transactionId = fraudTransactionId;
+                    LOGGER.info(
+                            "Third party transaction ids fraud {} pep {}",
+                            fraudTransactionId,
+                            pepTransactionId);
+
                     result.setContraIndicators(combinedContraIndicators.toArray(new String[] {}));
                     result.setIdentityCheckScore(identityCheckScore);
                     result.setTransactionId(transactionId);


### PR DESCRIPTION
## Proposed changes

### What changed

Removed the PEP ID from the VC

### Why did it change

There is a change to follow that will include both transactionIDs in the VC

