### PR TITLE
OJ-988 - Reinstate GHA submodules checkout

### DIFF
--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2

--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2


### PR DESCRIPTION
### What changed
- Add config to git checkout to include submodules

### Why did it change
- To correct a github actions execution failure

### Issue tracking
- [OJ-988](https://govukverify.atlassian.net/browse/OJ-988)
