### PR TITLE
LIME-191: Ensuring apis are uniquely named

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -174,7 +174,7 @@ Resources:
           "responseLength":"$context.responseLength"
           }
       TracingEnabled: true
-      Name: !Sub "fraud-cri-${AWS::StackName}"
+      Name: !Sub "${AWS::StackName}-PublicFraudApi"
       StageName: !Ref Environment
       DefinitionBody:
         openapi: "3.0.1" # workaround to get `sam validate` to work
@@ -256,7 +256,7 @@ Resources:
           "responseLength":"$context.responseLength"
           }
       TracingEnabled: true
-      Name: !Sub "fraud-cri-${AWS::StackName}"
+      Name: !Sub "${AWS::StackName}-PrivateFraudApi"
       StageName: !Ref Environment
       DefinitionBody:
         openapi: "3.0.1" # workaround to get `sam validate` to work


### PR DESCRIPTION
## Proposed changes

### What changed

Updated apigateway names to allow more accurate monitoring

### Why did it change

Because in fraud both apigateways shared the same name

### Issue tracking
- [LIME-191](https://govukverify.atlassian.net/browse/LIME-191)
