### PR TITLE
LIME-191: Updating description of APIs to trigger redeploy

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -148,7 +148,7 @@ Resources:
   PublicFraudApi:
     Type: AWS::Serverless::Api
     Properties:
-      Description: Public Fraud CRI API
+      Description: Public Fraud CRI API with metrics
       MethodSettings:
         - LoggingLevel: INFO
           ResourcePath: '/*'
@@ -230,7 +230,7 @@ Resources:
   PrivateFraudApi:
     Type: AWS::Serverless::Api
     Properties:
-      Description: Private Fraud CRI API
+      Description: Private Fraud CRI API with metrics
       MethodSettings:
         - LoggingLevel: INFO
           ResourcePath: '/*'


### PR DESCRIPTION
## Proposed changes

### What changed

Updated description of public and private apis

### Why did it change

To trigger apis to redeploy in fraud environments so the renaming appears in cloud watch

