### PR TITLE
LIME-189 Capture FraudCRI Metrics

### DIFF
--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationResponseMapperTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationResponseMapperTest.java
@@ -2,6 +2,11 @@ package uk.gov.di.ipv.cri.fraud.api.gateway;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.fraud.api.domain.FraudCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.*;
 import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
@@ -13,13 +18,25 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO_VALIDATION_FAIL;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO_VALIDATION_PASS;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_PEP_RESPONSE_TYPE_INFO;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_PEP_RESPONSE_TYPE_INFO_VALIDATION_FAIL;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_PEP_RESPONSE_TYPE_INFO_VALIDATION_PASS;
 
+@ExtendWith(MockitoExtension.class)
 class IdentityVerificationResponseMapperTest {
+    @Mock private EventProbe mockEventProbe;
     private IdentityVerificationResponseMapper responseMapper;
 
     @BeforeEach
     void setup() {
-        this.responseMapper = new IdentityVerificationResponseMapper();
+        this.responseMapper = new IdentityVerificationResponseMapper(mockEventProbe);
     }
 
     @Test
@@ -43,6 +60,11 @@ class IdentityVerificationResponseMapperTest {
                 this.responseMapper.mapIdentityVerificationResponse(
                         testIdentityVerificationResponse);
 
+        InOrder inOrder = inOrder(mockEventProbe);
+        inOrder.verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO);
+        inOrder.verify(mockEventProbe)
+                .counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO_VALIDATION_PASS);
+
         assertNotNull(fraudCheckResult);
         assertTrue(fraudCheckResult.isExecutedSuccessfully());
         assertNull(fraudCheckResult.getErrorMessage());
@@ -60,6 +82,11 @@ class IdentityVerificationResponseMapperTest {
         FraudCheckResult fraudCheckResult =
                 this.responseMapper.mapIdentityVerificationResponse(
                         testIdentityVerificationResponse);
+
+        InOrder inOrder = inOrder(mockEventProbe);
+        inOrder.verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO);
+        inOrder.verify(mockEventProbe)
+                .counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO_VALIDATION_FAIL);
 
         final String EXPECTED_ERROR =
                 IdentityVerificationResponseMapper.IV_INFO_RESPONSE_VALIDATION_FAILED_MSG;
@@ -87,6 +114,8 @@ class IdentityVerificationResponseMapperTest {
         FraudCheckResult fraudCheckResult =
                 this.responseMapper.mapIdentityVerificationResponse(
                         testIdentityVerificationResponse);
+
+        verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR);
 
         assertEquals(responseHeader, testIdentityVerificationResponse.getResponseHeader());
         assertEquals(TYPE, testIdentityVerificationResponse.getResponseHeader().getResponseType());
@@ -128,6 +157,8 @@ class IdentityVerificationResponseMapperTest {
                 this.responseMapper.mapIdentityVerificationResponse(
                         testIdentityVerificationResponse);
 
+        verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR);
+
         assertEquals(responseHeader, testIdentityVerificationResponse.getResponseHeader());
         assertEquals(TYPE, testIdentityVerificationResponse.getResponseHeader().getResponseType());
         assertEquals(
@@ -167,6 +198,8 @@ class IdentityVerificationResponseMapperTest {
         FraudCheckResult fraudCheckResult =
                 this.responseMapper.mapIdentityVerificationResponse(
                         testIdentityVerificationResponse);
+
+        verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR);
 
         assertEquals(responseHeader, testIdentityVerificationResponse.getResponseHeader());
         assertEquals(TYPE, testIdentityVerificationResponse.getResponseHeader().getResponseType());
@@ -208,6 +241,8 @@ class IdentityVerificationResponseMapperTest {
                 this.responseMapper.mapIdentityVerificationResponse(
                         testIdentityVerificationResponse);
 
+        verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR);
+
         assertEquals(responseHeader, testIdentityVerificationResponse.getResponseHeader());
         assertEquals(TYPE, testIdentityVerificationResponse.getResponseHeader().getResponseType());
         assertEquals(
@@ -248,6 +283,8 @@ class IdentityVerificationResponseMapperTest {
         FraudCheckResult fraudCheckResult =
                 this.responseMapper.mapIdentityVerificationResponse(
                         testIdentityVerificationResponse);
+
+        verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR);
 
         assertEquals(responseHeader, testIdentityVerificationResponse.getResponseHeader());
         assertEquals(TYPE, testIdentityVerificationResponse.getResponseHeader().getResponseType());
@@ -291,6 +328,8 @@ class IdentityVerificationResponseMapperTest {
                 this.responseMapper.mapIdentityVerificationResponse(
                         testIdentityVerificationResponse);
 
+        verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR);
+
         assertEquals(responseHeader, testIdentityVerificationResponse.getResponseHeader());
         assertEquals(TYPE, testIdentityVerificationResponse.getResponseHeader().getResponseType());
         assertEquals(
@@ -333,6 +372,8 @@ class IdentityVerificationResponseMapperTest {
                 this.responseMapper.mapIdentityVerificationResponse(
                         testIdentityVerificationResponse);
 
+        verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR);
+
         assertEquals(responseHeader, testIdentityVerificationResponse.getResponseHeader());
         assertEquals(TYPE, testIdentityVerificationResponse.getResponseHeader().getResponseType());
         assertEquals(
@@ -368,8 +409,12 @@ class IdentityVerificationResponseMapperTest {
         List<Rule> rules = List.of(rule);
         decisionElement.setRules(rules);
 
-        FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(testPEPResponse);
+        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+
+        InOrder inOrder = inOrder(mockEventProbe);
+        inOrder.verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_INFO);
+        inOrder.verify(mockEventProbe)
+                .counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_INFO_VALIDATION_PASS);
 
         assertNotNull(fraudCheckResult);
         assertTrue(fraudCheckResult.isExecutedSuccessfully());
@@ -384,8 +429,12 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.getResponseHeader().setTenantID(null);
 
-        FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(testPEPResponse);
+        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+
+        InOrder inOrder = inOrder(mockEventProbe);
+        inOrder.verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_INFO);
+        inOrder.verify(mockEventProbe)
+                .counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_INFO_VALIDATION_FAIL);
 
         final String EXPECTED_ERROR =
                 IdentityVerificationResponseMapper.IV_INFO_RESPONSE_VALIDATION_FAILED_MSG;
@@ -409,8 +458,9 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.setResponseHeader(responseHeader);
 
-        FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(testPEPResponse);
+        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+
+        verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR);
 
         assertEquals(responseHeader, testPEPResponse.getResponseHeader());
         assertEquals(TYPE, testPEPResponse.getResponseHeader().getResponseType());
@@ -443,8 +493,9 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.setResponseHeader(responseHeader);
 
-        FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(testPEPResponse);
+        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+
+        verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR);
 
         assertEquals(responseHeader, testPEPResponse.getResponseHeader());
         assertEquals(TYPE, testPEPResponse.getResponseHeader().getResponseType());
@@ -477,8 +528,9 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.setResponseHeader(responseHeader);
 
-        FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(testPEPResponse);
+        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+
+        verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR);
 
         assertEquals(responseHeader, testPEPResponse.getResponseHeader());
         assertEquals(TYPE, testPEPResponse.getResponseHeader().getResponseType());
@@ -511,8 +563,9 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.setResponseHeader(responseHeader);
 
-        FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(testPEPResponse);
+        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+
+        verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR);
 
         assertEquals(responseHeader, testPEPResponse.getResponseHeader());
         assertEquals(TYPE, testPEPResponse.getResponseHeader().getResponseType());
@@ -546,8 +599,9 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.setResponseHeader(responseHeader);
 
-        FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(testPEPResponse);
+        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+
+        verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR);
 
         assertEquals(responseHeader, testPEPResponse.getResponseHeader());
         assertEquals(TYPE, testPEPResponse.getResponseHeader().getResponseType());
@@ -581,8 +635,9 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.setResponseHeader(responseHeader);
 
-        FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(testPEPResponse);
+        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+
+        verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR);
 
         assertEquals(responseHeader, testPEPResponse.getResponseHeader());
         assertEquals(TYPE, testPEPResponse.getResponseHeader().getResponseType());
@@ -616,8 +671,9 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.setResponseHeader(responseHeader);
 
-        FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(testPEPResponse);
+        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+
+        verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR);
 
         assertEquals(responseHeader, testPEPResponse.getResponseHeader());
         assertEquals(TYPE, testPEPResponse.getResponseHeader().getResponseType());

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayTest.java
@@ -10,6 +10,7 @@ import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.fraud.api.domain.FraudCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.IdentityVerificationRequest;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.PEPRequest;
@@ -48,6 +49,8 @@ class ThirdPartyFraudGatewayTest {
         private final ObjectMapper objectMapper;
         private final HmacGenerator hmacGenerator;
         private final String experianEndpointUrl;
+        private final SleepHelper sleepHelper;
+        private final EventProbe eventProbe;
 
         private ExperianGatewayConstructorArgs(
                 HttpClient httpClient,
@@ -55,7 +58,9 @@ class ThirdPartyFraudGatewayTest {
                 IdentityVerificationResponseMapper responseMapper,
                 ObjectMapper objectMapper,
                 HmacGenerator hmacGenerator,
-                String experianEndpointUrl) {
+                String experianEndpointUrl,
+                SleepHelper sleepHelper,
+                EventProbe eventProbe) {
 
             this.httpClient = httpClient;
             this.requestMapper = requestMapper;
@@ -63,6 +68,8 @@ class ThirdPartyFraudGatewayTest {
             this.objectMapper = objectMapper;
             this.hmacGenerator = hmacGenerator;
             this.experianEndpointUrl = experianEndpointUrl;
+            this.sleepHelper = sleepHelper;
+            this.eventProbe = eventProbe;
         }
     }
 
@@ -75,6 +82,7 @@ class ThirdPartyFraudGatewayTest {
     @Mock private ObjectMapper mockObjectMapper;
     @Mock private HmacGenerator mockHmacGenerator;
     @Mock private SleepHelper sleepHelper;
+    @Mock private EventProbe eventProbe;
 
     @BeforeEach
     void setUp() {
@@ -86,7 +94,8 @@ class ThirdPartyFraudGatewayTest {
                         mockObjectMapper,
                         mockHmacGenerator,
                         TEST_ENDPOINT_URL,
-                        sleepHelper);
+                        sleepHelper,
+                        eventProbe);
     }
 
     @Test
@@ -472,14 +481,24 @@ class ThirdPartyFraudGatewayTest {
         Map<String, ExperianGatewayConstructorArgs> testCases =
                 Map.of(
                         "httpClient must not be null",
-                        new ExperianGatewayConstructorArgs(null, null, null, null, null, null),
+                        new ExperianGatewayConstructorArgs(
+                                null, null, null, null, null, null, null, null),
                         "requestMapper must not be null",
                         new ExperianGatewayConstructorArgs(
-                                Mockito.mock(HttpClient.class), null, null, null, null, null),
+                                Mockito.mock(HttpClient.class),
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null),
                         "responseMapper must not be null",
                         new ExperianGatewayConstructorArgs(
                                 Mockito.mock(HttpClient.class),
                                 Mockito.mock(IdentityVerificationRequestMapper.class),
+                                null,
+                                null,
                                 null,
                                 null,
                                 null,
@@ -491,6 +510,8 @@ class ThirdPartyFraudGatewayTest {
                                 Mockito.mock(IdentityVerificationResponseMapper.class),
                                 null,
                                 null,
+                                null,
+                                null,
                                 null),
                         "hmacGenerator must not be null",
                         new ExperianGatewayConstructorArgs(
@@ -498,6 +519,8 @@ class ThirdPartyFraudGatewayTest {
                                 Mockito.mock(IdentityVerificationRequestMapper.class),
                                 Mockito.mock(IdentityVerificationResponseMapper.class),
                                 Mockito.mock(ObjectMapper.class),
+                                null,
+                                null,
                                 null,
                                 null),
                         "crossCoreApiConfig must not be null",
@@ -507,6 +530,28 @@ class ThirdPartyFraudGatewayTest {
                                 Mockito.mock(IdentityVerificationResponseMapper.class),
                                 Mockito.mock(ObjectMapper.class),
                                 Mockito.mock(HmacGenerator.class),
+                                null,
+                                null,
+                                null),
+                        "sleepHelper must not be null",
+                        new ExperianGatewayConstructorArgs(
+                                Mockito.mock(HttpClient.class),
+                                Mockito.mock(IdentityVerificationRequestMapper.class),
+                                Mockito.mock(IdentityVerificationResponseMapper.class),
+                                Mockito.mock(ObjectMapper.class),
+                                Mockito.mock(HmacGenerator.class),
+                                TEST_ENDPOINT_URL,
+                                null,
+                                null),
+                        "eventProbe must not be null",
+                        new ExperianGatewayConstructorArgs(
+                                Mockito.mock(HttpClient.class),
+                                Mockito.mock(IdentityVerificationRequestMapper.class),
+                                Mockito.mock(IdentityVerificationResponseMapper.class),
+                                Mockito.mock(ObjectMapper.class),
+                                Mockito.mock(HmacGenerator.class),
+                                TEST_ENDPOINT_URL,
+                                Mockito.mock(SleepHelper.class),
                                 null));
 
         testCases.forEach(
@@ -520,7 +565,9 @@ class ThirdPartyFraudGatewayTest {
                                                 constructorArgs.responseMapper,
                                                 constructorArgs.objectMapper,
                                                 constructorArgs.hmacGenerator,
-                                                constructorArgs.experianEndpointUrl),
+                                                constructorArgs.experianEndpointUrl,
+                                                constructorArgs.sleepHelper,
+                                                constructorArgs.eventProbe),
                                 errorMessage));
     }
 

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/CredentialHandlerTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/CredentialHandlerTest.java
@@ -35,7 +35,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.LAMBDA_IDENTITY_CHECK_COMPLETED_ERROR;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.LAMBDA_IDENTITY_CHECK_COMPLETED_OK;
 
 @ExtendWith(MockitoExtension.class)
 class CredentialHandlerTest {
@@ -106,6 +109,8 @@ class CredentialHandlerTest {
         APIGatewayProxyResponseEvent responseEvent =
                 fraudHandler.handleRequest(mockRequestEvent, context);
 
+        verify(mockEventProbe).counterMetric(LAMBDA_IDENTITY_CHECK_COMPLETED_OK);
+
         assertNotNull(responseEvent);
         assertEquals(200, responseEvent.getStatusCode());
         assertEquals(
@@ -152,6 +157,8 @@ class CredentialHandlerTest {
         when(context.getFunctionVersion()).thenReturn("1.0");
         APIGatewayProxyResponseEvent responseEvent =
                 fraudHandler.handleRequest(mockRequestEvent, context);
+
+        verify(mockEventProbe).counterMetric(LAMBDA_IDENTITY_CHECK_COMPLETED_ERROR);
 
         assertNotNull(responseEvent);
         assertEquals(500, responseEvent.getStatusCode());

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
@@ -3,11 +3,13 @@ package uk.gov.di.ipv.cri.fraud.api.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.service.AuditService;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.fraud.api.domain.FraudCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.domain.IdentityVerificationResult;
 import uk.gov.di.ipv.cri.fraud.api.domain.ValidationResult;
@@ -22,8 +24,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.FRAUD_CHECK_REQUEST_FAILED;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.FRAUD_CHECK_REQUEST_SUCCEEDED;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.IDENTITY_CHECK_SCORE_PREFIX;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.PEP_CHECK_REQUEST_SUCCEEDED;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.PERSON_DETAILS_VALIDATION_FAIL;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.PERSON_DETAILS_VALIDATION_PASS;
 
 @ExtendWith(MockitoExtension.class)
 class IdentityVerificationServiceTest {
@@ -34,7 +45,9 @@ class IdentityVerificationServiceTest {
     @Mock private AuditService mockAuditService;
     @Mock private SessionItem sessionItem;
     @Mock private Map<String, String> requestHeaders;
-    @Mock private ConfigurationService configurationService;
+    @Mock private ConfigurationService mockConfigurationService;
+
+    @Mock private EventProbe mockEventProbe;
 
     private IdentityVerificationService identityVerificationService;
 
@@ -47,34 +60,77 @@ class IdentityVerificationServiceTest {
                         mockContraindicationMapper,
                         identityScoreCalculator,
                         mockAuditService,
-                        configurationService);
+                        mockConfigurationService,
+                        mockEventProbe);
     }
 
     @Test
     void verifyIdentityShouldReturnResultWhenValidInputProvided()
             throws IOException, InterruptedException {
         PersonIdentity testPersonIdentity = TestDataCreator.createTestPersonIdentity();
+
         FraudCheckResult testFraudCheckResult = new FraudCheckResult();
         testFraudCheckResult.setExecutedSuccessfully(true);
-        String[] thirdPartyFraudCodes = new String[] {"sample-code"};
-        String[] mappedFraudCodes = new String[] {"mapped-code"};
+
+        FraudCheckResult testPEPCheckResult = new FraudCheckResult();
+        testPEPCheckResult.setExecutedSuccessfully(true);
+
+        String[] thirdPartyFraudCodes = new String[] {"sample-f-code"};
+        String[] mappedFraudCodes = new String[] {"mapped-f-code"};
+        String[] thirdPartyPEPCodes = new String[] {"sample-p-code"};
+        String[] mappedPEPCodes = new String[] {"mapped-p-code"};
         testFraudCheckResult.setThirdPartyFraudCodes(thirdPartyFraudCodes);
+        testPEPCheckResult.setThirdPartyFraudCodes(thirdPartyPEPCodes);
+
         when(personIdentityValidator.validate(testPersonIdentity))
                 .thenReturn(ValidationResult.createValidResult());
+
+        when(mockConfigurationService.getPepEnabled()).thenReturn(Boolean.TRUE);
+
         when(mockThirdPartyGateway.performFraudCheck(testPersonIdentity, false))
                 .thenReturn(testFraudCheckResult);
         when(mockContraindicationMapper.mapThirdPartyFraudCodes(thirdPartyFraudCodes))
                 .thenReturn(mappedFraudCodes);
 
+        when(mockThirdPartyGateway.performFraudCheck(testPersonIdentity, true))
+                .thenReturn(testPEPCheckResult);
+        when(mockContraindicationMapper.mapThirdPartyFraudCodes(thirdPartyPEPCodes))
+                .thenReturn(mappedPEPCodes);
+
+        when(identityScoreCalculator.calculateIdentityScore(
+                        testFraudCheckResult.isExecutedSuccessfully(), false))
+                .thenReturn(1);
+        when(identityScoreCalculator.calculateIdentityScore(
+                        testFraudCheckResult.isExecutedSuccessfully(),
+                        testPEPCheckResult.isExecutedSuccessfully()))
+                .thenReturn(2);
+
         IdentityVerificationResult result =
                 this.identityVerificationService.verifyIdentity(
                         testPersonIdentity, sessionItem, requestHeaders);
 
+        InOrder inOrder = inOrder(mockEventProbe);
+
+        inOrder.verify(mockEventProbe).counterMetric(PERSON_DETAILS_VALIDATION_PASS);
+        inOrder.verify(mockEventProbe).counterMetric(FRAUD_CHECK_REQUEST_SUCCEEDED);
+        inOrder.verify(mockEventProbe).counterMetric(PEP_CHECK_REQUEST_SUCCEEDED);
+        inOrder.verify(mockEventProbe).counterMetric(IDENTITY_CHECK_SCORE_PREFIX + 2);
+
         assertNotNull(result);
-        assertEquals(mappedFraudCodes[0], result.getContraIndicators()[0]);
+        assertTrue(result.isSuccess());
+        assertEquals(mappedPEPCodes[0], result.getContraIndicators()[0]);
+        assertEquals(mappedFraudCodes[0], result.getContraIndicators()[1]);
         verify(personIdentityValidator).validate(testPersonIdentity);
         verify(mockThirdPartyGateway).performFraudCheck(testPersonIdentity, false);
         verify(mockContraindicationMapper).mapThirdPartyFraudCodes(thirdPartyFraudCodes);
+        verify(mockThirdPartyGateway).performFraudCheck(testPersonIdentity, true);
+        verify(mockContraindicationMapper).mapThirdPartyFraudCodes(thirdPartyPEPCodes);
+        verify(identityScoreCalculator)
+                .calculateIdentityScore(testFraudCheckResult.isExecutedSuccessfully(), false);
+        verify(identityScoreCalculator)
+                .calculateIdentityScore(
+                        testFraudCheckResult.isExecutedSuccessfully(),
+                        testPEPCheckResult.isExecutedSuccessfully());
     }
 
     @Test
@@ -87,6 +143,13 @@ class IdentityVerificationServiceTest {
         IdentityVerificationResult result =
                 this.identityVerificationService.verifyIdentity(
                         testPersonIdentity, sessionItem, requestHeaders);
+
+        InOrder inOrder = inOrder(mockEventProbe);
+        inOrder.verify(mockEventProbe).counterMetric(PERSON_DETAILS_VALIDATION_FAIL);
+        inOrder.verify(mockEventProbe, never()).counterMetric(FRAUD_CHECK_REQUEST_SUCCEEDED);
+        inOrder.verify(mockEventProbe, never()).counterMetric(PEP_CHECK_REQUEST_SUCCEEDED);
+        inOrder.verify(mockEventProbe, never()).counterMetric(IDENTITY_CHECK_SCORE_PREFIX + 1);
+        inOrder.verify(mockEventProbe, never()).counterMetric(IDENTITY_CHECK_SCORE_PREFIX + 2);
 
         assertNotNull(result);
         assertNull(result.getContraIndicators());
@@ -105,6 +168,11 @@ class IdentityVerificationServiceTest {
         IdentityVerificationResult result =
                 this.identityVerificationService.verifyIdentity(
                         testPersonIdentity, sessionItem, requestHeaders);
+
+        InOrder inOrder = inOrder(mockEventProbe);
+        inOrder.verify(mockEventProbe).counterMetric(PERSON_DETAILS_VALIDATION_PASS);
+        inOrder.verify(mockEventProbe, never()).counterMetric(IDENTITY_CHECK_SCORE_PREFIX + 1);
+        inOrder.verify(mockEventProbe).counterMetric(FRAUD_CHECK_REQUEST_FAILED);
 
         assertNotNull(result);
         assertFalse(result.isSuccess());

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactoryTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactoryTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.service.AuditService;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 
 import java.net.http.HttpClient;
 import java.security.InvalidKeyException;
@@ -25,6 +26,8 @@ class ServiceFactoryTest {
 
     @Mock private AuditService mockAuditService;
 
+    @Mock private EventProbe mockEventProbe;
+
     @Test
     void shouldCreateIdentityVerificationService()
             throws NoSuchAlgorithmException, InvalidKeyException {
@@ -33,6 +36,7 @@ class ServiceFactoryTest {
         ServiceFactory serviceFactory =
                 new ServiceFactory(
                         mockObjectMapper,
+                        mockEventProbe,
                         mockConfigurationService,
                         mockSslContextFactory,
                         mockContraindicationMapper,

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -5,7 +5,8 @@ plugins {
 }
 
 dependencies {
-	implementation configurations.cri_common_lib,
+	implementation project(":lib"),
+			configurations.cri_common_lib,
 			configurations.aws,
 			configurations.lambda,
 			configurations.nimbus,

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,18 +1,14 @@
 plugins {
-	id "java"
+	id "java-library"
 	id "jacoco"
 	id "io.freefair.aspectj.post-compile-weaving" version "6.3.0"
 }
 
 dependencies {
-	implementation project(":lib"),
-			configurations.cri_common_lib,
+
+	implementation configurations.cri_common_lib,
 			configurations.aws,
-			configurations.lambda,
-			configurations.nimbus,
-			configurations.dynamodb,
-			configurations.jackson,
-			configurations.sqs
+			configurations.dynamodb
 
 	aspect configurations.powertools
 
@@ -21,14 +17,20 @@ dependencies {
 	testRuntimeOnly configurations.test_runtime
 }
 
+tasks.named("jar") {
+	manifest {
+		attributes("Implementation-Title": project.name,
+		"Implementation-Version": project.version)
+	}
+}
+
 test {
 	useJUnitPlatform()
 	finalizedBy jacocoTestReport
 }
-
 jacocoTestReport {
 	dependsOn test
 	reports {
-		xml.enabled true
+		xml.required.set(true)
 	}
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/Definitions.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/Definitions.java
@@ -1,0 +1,80 @@
+package uk.gov.di.ipv.cri.fraud.library.metrics;
+
+public class Definitions {
+
+    // TODO Remove these first two metrics when safe
+    //  - Kept until alerts are converted to the _completed metrics
+    // They are named incorrectly, inconsistently placed and called.
+    // The LAMBDA_NAME_COMPLETED metrics are the replacements
+    public static final String TODO_REMOVE_BK_COMPAT_M1 = "fraud_issue_credential";
+    public static final String TODO_REMOVE_BK_COMPAT_M2 = "fraud_credential_issuer";
+
+    // These completed metrics record all escape routes from the lambdas.
+    // OK for expected routes with ERROR being all others
+    public static final String LAMBDA_IDENTITY_CHECK_COMPLETED_OK =
+            "lambda_identity_check_completed_ok";
+    public static final String LAMBDA_IDENTITY_CHECK_COMPLETED_ERROR =
+            "lambda_identity_check_completed_error";
+    public static final String LAMBDA_ISSUE_CREDENTIAL_COMPLETED_OK =
+            "lambda_issue_credential_completed_ok";
+    public static final String LAMBDA_ISSUE_CREDENTIAL_COMPLETED_ERROR =
+            "lambda_issue_credential_completed_error";
+
+    // PersonIdentityValidator
+    public static final String PERSON_DETAILS_VALIDATION_PASS = "person_details_validation_pass";
+    public static final String PERSON_DETAILS_VALIDATION_FAIL = "person_details_validation_fail";
+
+    // Fraud Check Request
+    public static final String FRAUD_CHECK_REQUEST_SUCCEEDED = "fraud_check_request_succeeded";
+    public static final String FRAUD_CHECK_REQUEST_FAILED = "fraud_check_request_failed";
+
+    // PEP Check Request
+    public static final String PEP_CHECK_REQUEST_SUCCEEDED = "pep_check_request_succeeded";
+    public static final String PEP_CHECK_REQUEST_FAILED = "pep_check_request_failed";
+
+    // OverallScore (Score is appended)
+    public static final String IDENTITY_CHECK_SCORE_PREFIX = "identity_check_score_";
+
+    // Per response Contra Indicators (CI is Appended)
+    public static final String FRAUD_CHECK_CI_PREFIX = "fraud_check_ci_";
+    public static final String PEP_CHECK_CI_PREFIX = "pep_check_ci_";
+
+    // HTTP Connection Send (Both)
+    public static final String THIRD_PARTY_REQUEST_CREATED = "third_party_requests_created";
+    public static final String THIRD_PARTY_REQUEST_SEND_OK = "third_party_requests_send_ok";
+    public static final String THIRD_PARTY_REQUEST_SEND_RETRY = "third_party_requests_send_retry";
+    public static final String THIRD_PARTY_REQUEST_SEND_FAIL =
+            "third_party_requests_send_fail"; // IOException
+
+    // Third Party Response Type Fraud
+    public static final String THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO =
+            "third_party_fraud_response_type_info";
+    public static final String THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR =
+            "third_party_fraud_response_type_error";
+    public static final String THIRD_PARTY_FRAUD_RESPONSE_TYPE_UNKNOWN =
+            "third_party_fraud_response_type_unknown";
+
+    // Third Party Response Type PEP
+    public static final String THIRD_PARTY_PEP_RESPONSE_TYPE_INFO =
+            "third_party_pep_response_type_info";
+    public static final String THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR =
+            "third_party_pep_response_type_error";
+    public static final String THIRD_PARTY_PEP_RESPONSE_TYPE_UNKNOWN =
+            "third_party_pep_response_type_unknown";
+
+    // IdentityVerificationInfoResponseValidator Fraud
+    public static final String THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO_VALIDATION_PASS =
+            "third_party_fraud_response_type_info_validation_pass";
+    public static final String THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO_VALIDATION_FAIL =
+            "third_party_fraud_response_type_info_validation_fail";
+
+    // IdentityVerificationInfoResponseValidator PEP
+    public static final String THIRD_PARTY_PEP_RESPONSE_TYPE_INFO_VALIDATION_PASS =
+            "third_party_pep_response_type_info_validation_pass";
+    public static final String THIRD_PARTY_PEP_RESPONSE_TYPE_INFO_VALIDATION_FAIL =
+            "third_party_pep_response_type_info_validation_fail";
+
+    private Definitions() {
+        throw new IllegalStateException("Instantiation is not valid for this class.");
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,9 @@ pluginManagement {
 
 rootProject.name = "di-ipv-cri-fraud-api"
 
+// Internal CRI Lib
+include "lib"
+
 // CRI specific lambdas
 include "issuecredential", "fraudcheck"
 project(':fraudcheck').projectDir = new File('./lambdas/fraudcheck')


### PR DESCRIPTION
## Proposed changes

### What changed

Added metrics to FraudCRI FraudCheck Lambda

Identity Check - Completed ok/error
Issue Credential - Completed ok/error
PersonIdentityValidator - pass/fail
Fraud Check Request - succeeded/failed
PEP Check Request - succeeded/failed
OverallScore - 0/1/2
Fraud response Contra Indicators - generated
PEP response Contra Indicators - generated
HTTP Connection Send - request_created/send_ok/send_retry/send_fail
Third Party Response Type Fraud - info/error/unknown
Third Party Response Type PEP - info/error/unknown
IdentityVerificationInfoResponseValidator Fraud - pass/fail
IdentityVerificationInfoResponseValidator PEP - pass/fail

Kept the two existing metrics in place until alarms and panels are converted over.

Added internal lib for fraudCRI

Corrected unit tests in IdentityVerificationResponseMapperTest calling the incorrect mapping response for pep checks.

Added verification that metrics are called to all test of impacted classes.

### Why did it change

Metrics added to cover metrics requested for LIME-189

Internal lib created so there is just one location (...fraud/library/metrics/Definitions.java) within FraudCRI for defining event probe metrics.

### Issue tracking

- [LIME-189](https://govukverify.atlassian.net/browse/LIME-189)