### PR TITLE
LIME-253: Adding decision score from the fraud check to the TxMA cred issued event

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/IdentityVerificationResult.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/IdentityVerificationResult.java
@@ -9,6 +9,7 @@ public class IdentityVerificationResult {
     private String[] contraIndicators;
     private int identityCheckScore;
     private String transactionId;
+    private String decisionScore;
 
     public boolean isSuccess() {
         return success;
@@ -56,5 +57,13 @@ public class IdentityVerificationResult {
 
     public void setTransactionId(String transactionId) {
         this.transactionId = transactionId;
+    }
+
+    public String getDecisionScore() {
+        return decisionScore;
+    }
+
+    public void setDecisionScore(String decisionScore) {
+        this.decisionScore = decisionScore;
     }
 }

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
@@ -153,7 +153,8 @@ public class FraudHandler
                     new FraudResultItem(
                             UUID.fromString(sessionId),
                             Arrays.asList(result.getContraIndicators()),
-                            result.getIdentityCheckScore());
+                            result.getIdentityCheckScore(),
+                            result.getDecisionScore());
             fraudResultItem.setTransactionId(result.getTransactionId());
 
             LOGGER.info("Saving fraud results...");

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/persistence/item/FraudResultItem.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/persistence/item/FraudResultItem.java
@@ -12,14 +12,19 @@ public class FraudResultItem {
     private List<String> contraIndicators;
     private Integer identityFraudScore;
     private String transactionId;
+    private String decisionScore;
 
     public FraudResultItem() {}
 
     public FraudResultItem(
-            UUID sessionId, List<String> contraIndicators, Integer identityFraudScore) {
+            UUID sessionId,
+            List<String> contraIndicators,
+            Integer identityFraudScore,
+            String decisionScore) {
         this.sessionId = sessionId;
         this.contraIndicators = contraIndicators;
         this.identityFraudScore = identityFraudScore;
+        this.decisionScore = decisionScore;
     }
 
     @DynamoDbPartitionKey()
@@ -53,5 +58,13 @@ public class FraudResultItem {
 
     public void setTransactionId(String transactionId) {
         this.transactionId = transactionId;
+    }
+
+    public String getDecisionScore() {
+        return decisionScore;
+    }
+
+    public void setDecisionScore(String decisionScore) {
+        this.decisionScore = decisionScore;
     }
 }

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
@@ -162,6 +162,8 @@ public class IdentityVerificationService {
 
                     String fraudTransactionId = fraudCheckResult.getTransactionId();
                     String transactionId = fraudTransactionId;
+                    String decisionScore = fraudCheckResult.getDecisionScore();
+
                     LOGGER.info(
                             "Third party transaction ids fraud {} pep {}",
                             fraudTransactionId,
@@ -177,6 +179,7 @@ public class IdentityVerificationService {
                     result.setContraIndicators(combinedContraIndicators.toArray(new String[] {}));
                     result.setIdentityCheckScore(identityCheckScore);
                     result.setTransactionId(transactionId);
+                    result.setDecisionScore(decisionScore);
                     // If fraudCheck succeeded a result can still be returned without pepCheck
                     // succeeding
                     result.setSuccess(fraudCheckResult.isExecutedSuccessfully());

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/CredentialHandlerTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/CredentialHandlerTest.java
@@ -81,6 +81,7 @@ class CredentialHandlerTest {
         testIdentityVerificationResult.setSuccess(true);
         testIdentityVerificationResult.setContraIndicators(new String[] {"A01"});
         testIdentityVerificationResult.setIdentityCheckScore(1);
+        testIdentityVerificationResult.setDecisionScore("90");
 
         APIGatewayProxyRequestEvent mockRequestEvent =
                 Mockito.mock(APIGatewayProxyRequestEvent.class);
@@ -114,7 +115,7 @@ class CredentialHandlerTest {
         assertNotNull(responseEvent);
         assertEquals(200, responseEvent.getStatusCode());
         assertEquals(
-                "{\"success\":true,\"validationErrors\":null,\"error\":null,\"contraIndicators\":[\"A01\"],\"identityCheckScore\":1,\"transactionId\":null}",
+                "{\"success\":true,\"validationErrors\":null,\"error\":null,\"contraIndicators\":[\"A01\"],\"identityCheckScore\":1,\"transactionId\":null,\"decisionScore\":\"90\"}",
                 responseEvent.getBody());
     }
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/audit/Evidence.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/audit/Evidence.java
@@ -19,6 +19,9 @@ public class Evidence {
     @JsonProperty("ci")
     private List<String> ci;
 
+    @JsonProperty("decisionScore")
+    private String decisionScore;
+
     public String getType() {
         return type;
     }
@@ -49,5 +52,13 @@ public class Evidence {
 
     public void setCi(List<String> ci) {
         this.ci = ci;
+    }
+
+    public String getDecisionScore() {
+        return decisionScore;
+    }
+
+    public void setDecisionScore(String decisionScore) {
+        this.decisionScore = decisionScore;
     }
 }

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/persistence/item/FraudResultItem.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/persistence/item/FraudResultItem.java
@@ -12,14 +12,19 @@ public class FraudResultItem {
     private List<String> contraIndicators;
     private Integer identityFraudScore;
     private String transactionId;
+    private String decisionScore;
 
     public FraudResultItem() {}
 
     public FraudResultItem(
-            UUID sessionId, List<String> contraIndicators, Integer identityFraudScore) {
+            UUID sessionId,
+            List<String> contraIndicators,
+            Integer identityFraudScore,
+            String decisionScore) {
         this.sessionId = sessionId;
         this.contraIndicators = contraIndicators;
         this.identityFraudScore = identityFraudScore;
+        this.decisionScore = decisionScore;
     }
 
     @DynamoDbPartitionKey()
@@ -53,5 +58,13 @@ public class FraudResultItem {
 
     public void setTransactionId(String transactionId) {
         this.transactionId = transactionId;
+    }
+
+    public String getDecisionScore() {
+        return decisionScore;
+    }
+
+    public void setDecisionScore(String decisionScore) {
+        this.decisionScore = decisionScore;
     }
 }

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/IssueCredentialFraudAuditExtensionUtil.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/IssueCredentialFraudAuditExtensionUtil.java
@@ -27,6 +27,7 @@ public class IssueCredentialFraudAuditExtensionUtil {
             evidence.setTxn(fraudResultItem.getTransactionId());
             evidence.setIdentityFraudScore(fraudResultItem.getIdentityFraudScore());
             evidence.setCi(fraudResultItem.getContraIndicators());
+            evidence.setDecisionScore(fraudResultItem.getDecisionScore());
 
             evidenceList.add(evidence);
         }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/IssueCredentialHandlerTest.java
@@ -76,7 +76,8 @@ class IssueCredentialHandlerTest {
                 FraudPersonIdentityDetailedMapper.generatePersonIdentityDetailed(
                         TestDataCreator.createTestPersonIdentity());
         SessionItem sessionItem = new SessionItem();
-        FraudResultItem fraudResultItem = new FraudResultItem(UUID.randomUUID(), List.of(""), 1);
+        FraudResultItem fraudResultItem =
+                new FraudResultItem(UUID.randomUUID(), List.of(""), 1, "90");
 
         when(mockSessionService.getSessionByAccessToken(accessToken)).thenReturn(sessionItem);
         when(mockPersonIdentityService.getPersonIdentityDetailed(any()))
@@ -136,7 +137,8 @@ class IssueCredentialHandlerTest {
                         TestDataCreator.createTestPersonIdentity());
 
         SessionItem sessionItem = new SessionItem();
-        FraudResultItem fraudResultItem = new FraudResultItem(UUID.randomUUID(), List.of(""), 1);
+        FraudResultItem fraudResultItem =
+                new FraudResultItem(UUID.randomUUID(), List.of(""), 1, "90");
 
         when(mockSessionService.getSessionByAccessToken(accessToken)).thenReturn(sessionItem);
         when(mockPersonIdentityService.getPersonIdentityDetailed(any()))

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/VerifiableCredentialServiceTest.java
@@ -71,7 +71,8 @@ class VerifiableCredentialServiceTest implements TestFixtures {
     @MethodSource("getAddressCount")
     void testGenerateSignedVerifiableCredentialJWTWithAddressCount(int addressCount)
             throws JOSEException, JsonProcessingException, ParseException {
-        FraudResultItem fraudResultItem = new FraudResultItem(UUID.randomUUID(), List.of("A01"), 1);
+        FraudResultItem fraudResultItem =
+                new FraudResultItem(UUID.randomUUID(), List.of("A01"), 1, "90");
 
         PersonIdentityDetailed personIdentityDetailed =
                 FraudPersonIdentityDetailedMapper.generatePersonIdentityDetailed(


### PR DESCRIPTION
## Proposed changes

### What changed

Updated fraud to:
Capture the decisionScore from Experian
Save the decisionScore
Record the decision score in the VC

### Why did it change

So we can track users with 0 decision score and where they originate from

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-253](https://govukverify.atlassian.net/browse/LIME-253)

