### PR TITLE
LIME-248: Updated score calculator

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationService.java
@@ -4,6 +4,8 @@ import com.nimbusds.oauth2.sdk.util.StringUtils;
 import software.amazon.lambda.powertools.parameters.ParamProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 import static software.amazon.lambda.powertools.parameters.transform.Transformer.json;
@@ -43,6 +45,8 @@ public class ConfigurationService {
     private final String contraindicationMappings;
     private final String parameterPrefix;
     private final String pepEnabled;
+    private List<String> zeroScoreUcodes;
+    private Integer noFileFoundThreshold;
 
     public ConfigurationService(
             SecretsProvider secretsProvider, ParamProvider paramProvider, String env) {
@@ -65,6 +69,10 @@ public class ConfigurationService {
         this.contraindicationMappings =
                 paramProvider.get(getParameterName("contraindicationMappings"));
         this.fraudResultTableName = paramProvider.get(getParameterName("FraudTableName"));
+        this.zeroScoreUcodes =
+                Arrays.asList(paramProvider.get(getParameterName("zeroScoreUcodes")).split(","));
+        this.noFileFoundThreshold =
+                Integer.valueOf(paramProvider.get(getParameterName("noFileFoundThreshold")));
 
         // *****************************Feature Toggles*******************************
 
@@ -117,6 +125,22 @@ public class ConfigurationService {
 
     public Boolean getPepEnabled() {
         return Boolean.valueOf(pepEnabled);
+    }
+
+    public List<String> getZeroScoreUcodes() {
+        return zeroScoreUcodes;
+    }
+
+    public void setZeroScoreUcodes(List<String> zeroScoreUcodes) {
+        this.zeroScoreUcodes = zeroScoreUcodes;
+    }
+
+    public Integer getNoFileFoundThreshold() {
+        return noFileFoundThreshold;
+    }
+
+    public void setNoFileFoundThreshold(Integer noFileFoundThreshold) {
+        this.noFileFoundThreshold = noFileFoundThreshold;
     }
 
     public String getParameterName(String parameterName) {

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculator.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculator.java
@@ -2,19 +2,47 @@ package uk.gov.di.ipv.cri.fraud.api.service;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.fraud.api.domain.FraudCheckResult;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class IdentityScoreCalculator {
 
     private static final Logger LOGGER = LogManager.getLogger();
+    private List<String> zeroScoreUcodes = new ArrayList<>();
+    private Integer noFileFoundThreshold = 0;
+
+    public IdentityScoreCalculator(ConfigurationService configurationService) {
+        zeroScoreUcodes = configurationService.getZeroScoreUcodes();
+        noFileFoundThreshold = configurationService.getNoFileFoundThreshold();
+    }
 
     public int calculateIdentityScore(
-            boolean thirdPartyFraudCheckSuccess, boolean thirdPartyPepCheckSuccess) {
-        if (thirdPartyFraudCheckSuccess && thirdPartyPepCheckSuccess) {
-            return 2;
-        } else if (thirdPartyFraudCheckSuccess && !thirdPartyPepCheckSuccess) {
+            FraudCheckResult fraudCheckResult, boolean thirdPartyPepCheckSuccess) {
+        boolean thirdPartyFraudCheckSuccess = fraudCheckResult.isExecutedSuccessfully();
+
+        if (thirdPartyFraudCheckSuccess) {
+            Integer decisionScore = Integer.valueOf(fraudCheckResult.getDecisionScore());
+            for (String zeroScoreUcode : zeroScoreUcodes) {
+                if (Arrays.asList(fraudCheckResult.getThirdPartyFraudCodes())
+                        .contains(zeroScoreUcode)) {
+                    LOGGER.info(
+                            "User has been identified as having a ucode that indicates they cannnot score higher than zero");
+                    return 0;
+                }
+            }
+            if (decisionScore <= noFileFoundThreshold) {
+                LOGGER.info(
+                        "Decision score was below the file found threshold they cannot score higher than one");
+                return 1;
+            }
+            if (thirdPartyPepCheckSuccess) {
+                return 2;
+            }
             return 1;
-        } else {
-            return 0;
         }
+        return 0;
     }
 }

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
@@ -113,8 +113,7 @@ public class IdentityVerificationService {
                             Arrays.toString(fraudCheckResult.getThirdPartyFraudCodes()));
 
                     int fraudIdentityCheckScore =
-                            identityScoreCalculator.calculateIdentityScore(
-                                    fraudCheckResult.isExecutedSuccessfully(), false);
+                            identityScoreCalculator.calculateIdentityScore(fraudCheckResult, false);
                     LOGGER.info(
                             "Fraud check passed successfully. Indicators {}, Score {}",
                             String.join(", ", fraudContraindications),
@@ -134,7 +133,7 @@ public class IdentityVerificationService {
                                                     pepCheckResult.getThirdPartyFraudCodes()));
                             pepIdentityCheckScore =
                                     identityScoreCalculator.calculateIdentityScore(
-                                            fraudCheckResult.isExecutedSuccessfully(),
+                                            fraudCheckResult,
                                             pepCheckResult.isExecutedSuccessfully());
                             pepTransactionId = pepCheckResult.getTransactionId();
                             LOGGER.info(

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactory.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactory.java
@@ -95,7 +95,8 @@ public class ServiceFactory {
                         configurationService.getEndpointUrl(),
                         eventProbe);
 
-        final IdentityScoreCalculator identityScoreCalculator = new IdentityScoreCalculator();
+        final IdentityScoreCalculator identityScoreCalculator =
+                new IdentityScoreCalculator(configurationService);
         return new IdentityVerificationService(
                 thirdPartyGateway,
                 personIdentityValidator,

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationServiceTest.java
@@ -47,7 +47,10 @@ class ConfigurationServiceTest {
                 .thenReturn(endpointValue);
         when(mockParamProvider.get(String.format(KEY_FORMAT, env, thirdPartyIdKey)))
                 .thenReturn(thirdPartyIdValue);
-
+        when(mockParamProvider.get("/null/FraudTableName")).thenReturn("None");
+        when(mockParamProvider.get("/null/contraindicationMappings")).thenReturn("null:null");
+        when(mockParamProvider.get("/null/zeroScoreUcodes")).thenReturn("U001,U002");
+        when(mockParamProvider.get("/null/noFileFoundThreshold")).thenReturn("35");
         when(mockSecretsProvider.get(String.format(KEY_FORMAT, env, hmacKey)))
                 .thenReturn(testHmacKeyValue);
         when(mockSecretsProvider.get(

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculatorTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculatorTest.java
@@ -1,0 +1,116 @@
+package uk.gov.di.ipv.cri.fraud.api.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.fraud.api.domain.FraudCheckResult;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.*;
+
+@ExtendWith(MockitoExtension.class)
+class IdentityScoreCalculatorTest {
+    @Mock private ConfigurationService mockConfigurationService;
+
+    private IdentityScoreCalculator identityScoreCalculator;
+
+    @Test
+    void testSuccessInFraudAndSuccessInPepIsScoreOfTwo() {
+        FraudCheckResult fraudCheckResult = new FraudCheckResult();
+        fraudCheckResult.setDecisionScore("40");
+        fraudCheckResult.setThirdPartyFraudCodes(new String[] {});
+        fraudCheckResult.setExecutedSuccessfully(true);
+        fraudCheckResult.setTransactionId("123456789");
+
+        when(mockConfigurationService.getZeroScoreUcodes()).thenReturn(List.of("U001"));
+        when(mockConfigurationService.getNoFileFoundThreshold()).thenReturn(35);
+        this.identityScoreCalculator = new IdentityScoreCalculator(mockConfigurationService);
+
+        int identityScore = identityScoreCalculator.calculateIdentityScore(fraudCheckResult, true);
+        assertEquals(identityScore, 2);
+    }
+
+    @Test
+    void testSuccessInFraudAndSuccessInPepWithDecisionScoreBelow35IsScoreOfOne() {
+        FraudCheckResult fraudCheckResult = new FraudCheckResult();
+        fraudCheckResult.setDecisionScore("30");
+        fraudCheckResult.setThirdPartyFraudCodes(new String[] {});
+        fraudCheckResult.setExecutedSuccessfully(true);
+        fraudCheckResult.setTransactionId("123456789");
+
+        when(mockConfigurationService.getZeroScoreUcodes()).thenReturn(List.of("U001"));
+        when(mockConfigurationService.getNoFileFoundThreshold()).thenReturn(35);
+        this.identityScoreCalculator = new IdentityScoreCalculator(mockConfigurationService);
+
+        int identityScore = identityScoreCalculator.calculateIdentityScore(fraudCheckResult, true);
+        assertEquals(identityScore, 1);
+    }
+
+    @Test
+    void testSuccessInFraudAndSuccessInPepWithZeroScoreUcodeIsScoreOfZero() {
+        FraudCheckResult fraudCheckResult = new FraudCheckResult();
+        fraudCheckResult.setDecisionScore("45");
+        fraudCheckResult.setThirdPartyFraudCodes(new String[] {"U001"});
+        fraudCheckResult.setExecutedSuccessfully(true);
+        fraudCheckResult.setTransactionId("123456789");
+
+        when(mockConfigurationService.getZeroScoreUcodes()).thenReturn(List.of("U001"));
+        when(mockConfigurationService.getNoFileFoundThreshold()).thenReturn(35);
+        this.identityScoreCalculator = new IdentityScoreCalculator(mockConfigurationService);
+
+        int identityScore = identityScoreCalculator.calculateIdentityScore(fraudCheckResult, true);
+        assertEquals(identityScore, 0);
+    }
+
+    @Test
+    void testSuccessInFraudAndFailInPepIsScoreOfOne() {
+        FraudCheckResult fraudCheckResult = new FraudCheckResult();
+        fraudCheckResult.setDecisionScore("45");
+        fraudCheckResult.setThirdPartyFraudCodes(new String[] {});
+        fraudCheckResult.setExecutedSuccessfully(true);
+        fraudCheckResult.setTransactionId("123456789");
+
+        when(mockConfigurationService.getZeroScoreUcodes()).thenReturn(List.of("U001"));
+        when(mockConfigurationService.getNoFileFoundThreshold()).thenReturn(35);
+        this.identityScoreCalculator = new IdentityScoreCalculator(mockConfigurationService);
+
+        int identityScore = identityScoreCalculator.calculateIdentityScore(fraudCheckResult, false);
+        assertEquals(identityScore, 1);
+    }
+
+    @Test
+    void testFailInFraudAndFailInPepIsScoreOfZero() {
+        FraudCheckResult fraudCheckResult = new FraudCheckResult();
+        fraudCheckResult.setDecisionScore("45");
+        fraudCheckResult.setThirdPartyFraudCodes(new String[] {});
+        fraudCheckResult.setExecutedSuccessfully(false);
+        fraudCheckResult.setTransactionId("123456789");
+
+        when(mockConfigurationService.getZeroScoreUcodes()).thenReturn(List.of("U001"));
+        when(mockConfigurationService.getNoFileFoundThreshold()).thenReturn(35);
+        this.identityScoreCalculator = new IdentityScoreCalculator(mockConfigurationService);
+
+        int identityScore = identityScoreCalculator.calculateIdentityScore(fraudCheckResult, false);
+        assertEquals(identityScore, 0);
+    }
+
+    @Test
+    void testFailInFraudAndSuccessInPepIsScoreOfZero() {
+        FraudCheckResult fraudCheckResult = new FraudCheckResult();
+        fraudCheckResult.setDecisionScore("45");
+        fraudCheckResult.setThirdPartyFraudCodes(new String[] {});
+        fraudCheckResult.setExecutedSuccessfully(false);
+        fraudCheckResult.setTransactionId("123456789");
+
+        when(mockConfigurationService.getZeroScoreUcodes()).thenReturn(List.of("U001"));
+        when(mockConfigurationService.getNoFileFoundThreshold()).thenReturn(35);
+        this.identityScoreCalculator = new IdentityScoreCalculator(mockConfigurationService);
+        int identityScore = identityScoreCalculator.calculateIdentityScore(fraudCheckResult, true);
+
+        assertEquals(identityScore, 0);
+    }
+}

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
@@ -97,12 +97,10 @@ class IdentityVerificationServiceTest {
         when(mockContraindicationMapper.mapThirdPartyFraudCodes(thirdPartyPEPCodes))
                 .thenReturn(mappedPEPCodes);
 
-        when(identityScoreCalculator.calculateIdentityScore(
-                        testFraudCheckResult.isExecutedSuccessfully(), false))
+        when(identityScoreCalculator.calculateIdentityScore(testFraudCheckResult, false))
                 .thenReturn(1);
         when(identityScoreCalculator.calculateIdentityScore(
-                        testFraudCheckResult.isExecutedSuccessfully(),
-                        testPEPCheckResult.isExecutedSuccessfully()))
+                        testFraudCheckResult, testPEPCheckResult.isExecutedSuccessfully()))
                 .thenReturn(2);
 
         IdentityVerificationResult result =
@@ -125,12 +123,10 @@ class IdentityVerificationServiceTest {
         verify(mockContraindicationMapper).mapThirdPartyFraudCodes(thirdPartyFraudCodes);
         verify(mockThirdPartyGateway).performFraudCheck(testPersonIdentity, true);
         verify(mockContraindicationMapper).mapThirdPartyFraudCodes(thirdPartyPEPCodes);
-        verify(identityScoreCalculator)
-                .calculateIdentityScore(testFraudCheckResult.isExecutedSuccessfully(), false);
+        verify(identityScoreCalculator).calculateIdentityScore(testFraudCheckResult, false);
         verify(identityScoreCalculator)
                 .calculateIdentityScore(
-                        testFraudCheckResult.isExecutedSuccessfully(),
-                        testPEPCheckResult.isExecutedSuccessfully());
+                        testFraudCheckResult, testPEPCheckResult.isExecutedSuccessfully());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

Fraud score calculator updated.
Two new parameters added for no file found with third party threshold and ucodes that if received do not allow the score beyond 0.

### Why did it change

Changed following a review of the fraud process with Experian and what should happen if the user cannot be found within the thirdparty records

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-248](https://govukverify.atlassian.net/browse/LIME-248)

