### PR TITLE
LIME-173 send IPV_FRAUD_CRI_END audit event.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ ext {
 		nimbusds_jwt_version        : "9.15.1",
 		protobuf_version            : "3.19.4",
 		junit                       : "5.8.2",
-		mockito					    : "4.3.1",
-		cri_common_lib              : "1.1.4"
+		mockito                     : "4.3.1",
+		cri_common_lib              : "1.3.1"
 	]
 }
 

--- a/lambdas/fraudcheck/build.gradle
+++ b/lambdas/fraudcheck/build.gradle
@@ -29,6 +29,6 @@ test {
 jacocoTestReport {
 	dependsOn test
 	reports {
-		xml.enabled true
+		xml.required.set(true)
 	}
 }

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id "java"
-	id "io.freefair.aspectj.post-compile-weaving" version "6.3.0"
 	id "jacoco"
+	id "io.freefair.aspectj.post-compile-weaving" version "6.3.0"
 }
 
 dependencies {
@@ -12,11 +12,13 @@ dependencies {
 			configurations.nimbus,
 			configurations.dynamodb,
 			configurations.jackson,
-			configurations.sqs
+			configurations.sqs,
+			configurations.kms
 
 	aspect configurations.powertools
 
 	testImplementation configurations.tests
+
 	testRuntimeOnly configurations.test_runtime
 }
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/IssueCredentialHandler.java
@@ -130,6 +130,9 @@ public class IssueCredentialHandler
             // Lambda Complete No Error
             eventProbe.counterMetric(LAMBDA_ISSUE_CREDENTIAL_COMPLETED_OK);
 
+            auditService.sendAuditEvent(
+                    AuditEventType.END, new AuditEventContext(input.getHeaders(), sessionItem));
+
             return ApiGatewayResponseGenerator.proxyJwtResponse(
                     HttpStatusCode.OK, signedJWT.serialize());
         } catch (AwsServiceException ex) {


### PR DESCRIPTION
(Merge after https://github.com/alphagov/di-ipv-cri-lib/pull/106)

## Proposed changes

### What changed

Send CRI_END audit event when VC is being returned.

Add kms to issuecredential dependancies.

Update CRI lib version to 1.3.1

### Why did it change

CRI_END audit event added per LIME-173.

Adding kms dependancy to issuecredential due to auto resolution failing with a locally generated cri lib. This aligns issuecredential build with the fraudcheck lambda build which had no issue due to already having the dependancy present.

CRI lib 1.3.1 contains the change needed.

### Issue tracking

- [LIME-173](https://govukverify.atlassian.net/browse/LIME-173)
