### PR TITLE
LIME-243 - Extend VC Validity to 6 months for production environment

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -119,7 +119,7 @@ Mappings:
       build: "6"
       staging: "6"
       integration: "6"
-      production: "2"
+      production: "6"
 
   # Permitted values: SECONDS,MINUTES,HOURS,DAYS,MONTHS,YEARS
   JwtTtlUnitMapping:
@@ -128,7 +128,7 @@ Mappings:
       build: MONTHS
       staging: MONTHS
       integration: MONTHS
-      production: HOURS
+      production: MONTHS
 
   FraudCriAudienceMapping:
     Environment:


### PR DESCRIPTION
## Proposed changes

### What changed

- MaxJwtTtlMapping increased from 2 hours to 6 months.

### Issue tracking

- [LIME-243](https://govukverify.atlassian.net/browse/LIME-243)