### PR TITLE
LIME-117: Updated run-tests and build image to assume aws credentials

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -27,14 +27,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Construct tags string
         id: tags
         run: |
@@ -43,6 +46,7 @@ jobs:
             TAGS="${TAGS},${GHCR_REPO}:${{ inputs.image_tag }},"
           fi
           echo "::set-output name=tags::$TAGS"
+
       - name: Build and export to Docker
         uses: docker/build-push-action@v2
         with:
@@ -50,6 +54,14 @@ jobs:
           file: acceptance-tests/Dockerfile
           load: true
           tags: ${{ steps.tags.outputs.tags }}
+
+      - name: Assume temporary AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: ${{ secrets.AWS_ROLE_SESSION }}
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Test image in build environment
         env:
           BROWSER: chrome-headless
@@ -60,16 +72,7 @@ jobs:
           orchestratorStubUrl: ${{ secrets.ORCHESTRATOR_STUB_URL }}
           NO_CHROME_SANDBOX: true
         run: docker run -e BROWSER -e NO_CHROME_SANDBOX -e ENVIRONMENT -e coreStubUrl -e coreStubUsername -e coreStubPassword -e orchestratorStubUrl "${GHCR_REPO}":latest ./gradlew fraudCriSmokeBuild
-      - name: Test image in staging environment
-        env:
-          BROWSER: chrome-headless
-          ENVIRONMENT: ${{ secrets.TEST_ENVIRONMENT }}
-          coreStubUrl: ${{ secrets.CORE_STUB_URL }}
-          coreStubUsername: ${{ secrets.CORE_STUB_USERNAME }}
-          coreStubPassword: ${{ secrets.CORE_STUB_PASSWORD }}
-          orchestratorStubUrl: ${{ secrets.ORCHESTRATOR_STUB_URL }}
-          NO_CHROME_SANDBOX: true
-        run: docker run -e BROWSER -e NO_CHROME_SANDBOX -e ENVIRONMENT -e coreStubUrl -e coreStubUsername -e coreStubPassword -e orchestratorStubUrl  "${GHCR_REPO}":latest ./gradlew fraudCriSmokeStaging
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -71,7 +71,8 @@ jobs:
           coreStubPassword: ${{ secrets.CORE_STUB_PASSWORD }}
           orchestratorStubUrl: ${{ secrets.ORCHESTRATOR_STUB_URL }}
           NO_CHROME_SANDBOX: true
-        run: docker run -e BROWSER -e NO_CHROME_SANDBOX -e ENVIRONMENT -e coreStubUrl -e coreStubUsername -e coreStubPassword -e orchestratorStubUrl "${GHCR_REPO}":latest ./gradlew fraudCriSmokeBuild
+          TEST_TAG: @build-fraud
+        run: docker run -e BROWSER -e NO_CHROME_SANDBOX -e ENVIRONMENT -e coreStubUrl -e coreStubUsername -e coreStubPassword -e orchestratorStubUrl -e TEST_TAG "${GHCR_REPO}":latest
 
       - name: Build and push
         uses: docker/build-push-action@v2

--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -32,6 +32,7 @@ fi
 echo "ENVIRONMENT ${ENVIRONMENT}"
 echo "STACK_NAME ${STACK_NAME}"
 
+if [ "${STACK_NAME}" != "local"]; then
 export JOURNEY_TAG=$(aws ssm get-parameter --name "/tests/${STACK_NAME}/TestTag" | jq -r ".Parameter.Value")
 
 PARAMETERS_NAMES=(coreStubPassword coreStubUrl coreStubUsername passportCriUrl apiBaseUrl orchestratorStubUrl)
@@ -45,6 +46,9 @@ do
 
   eval $(echo "export ${NAME}=${VALUE}")
 done
+else
+  export JOURNEY_TAG="${TEST_TAG}"
+fi
 
 pushd /home/gradle
 gradle cucumber -P tags=${JOURNEY_TAG}

--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -1,13 +1,37 @@
 #!/usr/bin/env bash
 
-set -eu
-
 REPORT_DIR="${TEST_REPORT_DIR:=$PWD}"
 
 export BROWSER="${BROWSER:-chrome-headless}"
 export ENVIRONMENT="${ENVIRONMENT:-build}"
 export NO_CHROME_SANDBOX=true
-export STACK_NAME="${CFN_StackName:-local}"
+
+
+# Added to accommodate ssm stack
+if [[ -z "${CFN_StackName}" ]]; then
+  if [[ -z "${SAM_STACK_NAME}" ]]; then
+    export STACK_NAME="local"
+  else
+    export STACK_NAME="${SAM_STACK_NAME}"
+  fi
+else
+  export STACK_NAME="${CFN_StackName}"
+fi
+
+# Added to accommodate ssm stack
+if [[ -z "${ENVIRONMENT}" ]]; then
+  if [[ -z "${TEST_ENVIRONMENT}" ]]; then
+    export ENVIRONMENT="build"
+  else
+    export ENVIRONMENT="${TEST_ENVIRONMENT}"
+  fi
+else
+  export ENVIRONMENT="${ENVIRONMENT}"
+fi
+
+echo "ENVIRONMENT ${ENVIRONMENT}"
+echo "STACK_NAME ${STACK_NAME}"
+
 export JOURNEY_TAG=$(aws ssm get-parameter --name "/tests/${STACK_NAME}/TestTag" | jq -r ".Parameter.Value")
 
 PARAMETERS_NAMES=(coreStubPassword coreStubUrl coreStubUsername passportCriUrl apiBaseUrl orchestratorStubUrl)


### PR DESCRIPTION
## Proposed changes

### What changed

Updated run-tests.sh to work with ssm param stack
and
Assumed permissions so that image can be tested before being pushed

### Why did it change

To allow image to be constructed and pushed for pipeline and to ensure image is properly tested

