### PR TITLE
LIME-257 Remove version pining of sam-cli 1.65.0 and python cryptogra…

### DIFF
--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -30,10 +30,6 @@ jobs:
 
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v1
-        with:
-          version: 1.65.0
-      - name: sam fix https://github.com/aws/aws-sam-cli/issues/4527
-        run: $(dirname $(readlink $(which sam)))/pip install --force-reinstall "cryptography==38.0.4"
 
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -30,10 +30,6 @@ jobs:
 
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v1
-        with:
-          version: 1.65.0
-      - name: sam fix https://github.com/aws/aws-sam-cli/issues/4527
-        run: $(dirname $(readlink $(which sam)))/pip install --force-reinstall "cryptography==38.0.4"
 
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -34,10 +34,6 @@ jobs:
 
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v1
-        with:
-          version: 1.65.0
-      - name: sam fix https://github.com/aws/aws-sam-cli/issues/4527
-        run: $(dirname $(readlink $(which sam)))/pip install --force-reinstall "cryptography==38.0.4"
 
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
## Proposed changes

### What changed

Remove temporary sam-cli build work around.

### Why did it change

aws-sam-cli version 1.68 is released which corrects the issue.

### Issue tracking

https://github.com/aws/aws-sam-cli/releases/tag/v1.68.0
