### PR TITLE
LIME-333 - Add logging & alerting into Fraud CRI for spike in fraud scores

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -756,10 +756,10 @@ Resources:
             Period: 300
             Stat: Sum
 
-  FraudPepScoreErrors:
+  FraudPepCheckFail:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: !Sub Fraud ${Environment} Fraud / Pep Score errors
+      AlarmDescription: !Sub Fraud ${Environment} PEP check failed
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlarmTopicFraud

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -756,6 +756,29 @@ Resources:
             Period: 300
             Stat: Sum
 
+  FraudAPIScoreErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: !Sub Fraud ${Environment} Fraud / Pep Score errors
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AlarmTopicFraud
+      OKActions:
+        - !Ref AlarmTopicFraud
+      InsufficientDataActions: []
+      Namespace: di-ipv-cri-fraud-api
+      MetricName: pep_check_request_failed
+      Statistic: Sum
+      Dimensions:
+        - Name: Service
+          Value: "di-ipv-cri-fraud-api-identitycheck"
+      Period: 300
+      DatapointsToAlarm: 3
+      EvaluationPeriods: 3
+      Threshold: 10
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
   ####################################################################
   #                                                                  #
   # Alarm setup                                                      #

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -756,7 +756,7 @@ Resources:
             Period: 300
             Stat: Sum
 
-  FraudAPIScoreErrors:
+  FraudPepScoreErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmDescription: !Sub Fraud ${Environment} Fraud / Pep Score errors


### PR DESCRIPTION
## Proposed changes

### What changed

Added logging & alerting into Fraud CRI for spike in fraud scores.

### Issue tracking

- [LIME-333](https://govukverify.atlassian.net/browse/LIME-333)

[LIME-333]: https://govukverify.atlassian.net/browse/LIME-333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ