### PR TITLE
LIME-406 - Replaced THIRD_PARTY_REQUEST_ENDED with RESPONSE_RECEIVED

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		protobuf_version            : "3.19.4",
 		junit                       : "5.8.2",
 		mockito                     : "4.3.1",
-		cri_common_lib              : "1.3.1"
+		cri_common_lib              : "1.4.1"
 	]
 }
 

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
@@ -148,7 +148,7 @@ public class IdentityVerificationService {
             LOGGER.info("Final Combined Indicators {}", stringCIs);
 
             auditService.sendAuditEvent(
-                    AuditEventType.THIRD_PARTY_REQUEST_ENDED,
+                    AuditEventType.RESPONSE_RECEIVED,
                     new AuditEventContext(requestHeaders, sessionItem),
                     new TPREFraudAuditExtension(identityVerificationResult.getContraIndicators()));
         }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/FraudAuditGeneratorTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/FraudAuditGeneratorTest.java
@@ -47,7 +47,7 @@ class FraudAuditGeneratorTest {
 
         TPREFraudAuditExtension tprefEXT = new TPREFraudAuditExtension(List.of("u101"));
 
-        AuditEventType evt1 = AuditEventType.THIRD_PARTY_REQUEST_ENDED;
+        AuditEventType evt1 = AuditEventType.RESPONSE_RECEIVED;
         AuditEvent<TPREFraudAuditExtension> ev1 =
                 new AuditEvent<>(000001L, "PREFIX" + "_" + evt1.toString(), "TEST");
 


### PR DESCRIPTION
Note: This PR will need to be merged after https://github.com/alphagov/di-ipv-cri-lib/pull/148

### What changed

Replaced THIRD_PARTY_REQUEST_ENDED with RESPONSE_RECEIVED
