### PR TITLE
Lime-257-checkDetails and failedCheckDetails test added to FraudCRI.feature

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
@@ -240,11 +240,7 @@ public class FraudPageObject extends UniversalSteps {
     }
 
     public void userNameInJsonResponse() throws JsonProcessingException {
-        String result = JSONPayload.getText();
-        LOGGER.info("result = " + result);
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode jsonNode = objectMapper.readTree(result);
-        JsonNode vcNode = jsonNode.get("vc");
+        JsonNode vcNode = getVCFromJson("vc");
         JsonNode nameNode = vcNode.get("credentialSubject");
         JsonNode insideName = nameNode.get("name");
         JsonNode nameContent = insideName.get(0);
@@ -253,12 +249,7 @@ public class FraudPageObject extends UniversalSteps {
 
     public void jsonErrorResponse(String testStatusCode) throws JsonProcessingException {
         String testErrorDescription = "general error";
-        String result = JSONPayload.getText();
-        LOGGER.info("result = " + result);
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode jsonNode = objectMapper.readTree(result);
-        JsonNode insideError = jsonNode.get("errorObject");
+        JsonNode insideError = getVCFromJson("errorObject");
         LOGGER.info("insideError = " + insideError);
         JsonNode errorDescription = insideError.get("description");
         JsonNode statusCode = insideError.get("httpstatusCode");
@@ -352,11 +343,7 @@ public class FraudPageObject extends UniversalSteps {
     }
 
     public void ciInVC(String ci) throws IOException {
-        String result = JSONPayload.getText();
-        LOGGER.info("result = " + result);
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode jsonNode = objectMapper.readTree(result);
-        JsonNode vcNode = jsonNode.get("vc");
+        JsonNode vcNode = getVCFromJson("vc");
         JsonNode evidenceNode = vcNode.get("evidence");
 
         ObjectReader objectReader =
@@ -379,11 +366,7 @@ public class FraudPageObject extends UniversalSteps {
     }
 
     public void identityScoreIs(String score) throws IOException {
-        String result = JSONPayload.getText();
-        LOGGER.info("result = " + result);
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode jsonNode = objectMapper.readTree(result);
-        JsonNode vcNode = jsonNode.get("vc");
+        JsonNode vcNode = getVCFromJson("vc");
         JsonNode evidenceNode = vcNode.get("evidence");
 
         ObjectReader objectReader =
@@ -407,11 +390,7 @@ public class FraudPageObject extends UniversalSteps {
     }
 
     private JsonNode userAddressInJsonResponse() throws JsonProcessingException {
-        String result = JSONPayload.getText();
-        LOGGER.info("result = " + result);
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode jsonNode = objectMapper.readTree(result);
-        JsonNode vcNode = jsonNode.get("vc");
+        JsonNode vcNode = getVCFromJson("vc");
         JsonNode addressNode = vcNode.get("credentialSubject");
         JsonNode insideAddress = addressNode.get("address");
         JsonNode addressContent = insideAddress.get(0);
@@ -419,11 +398,7 @@ public class FraudPageObject extends UniversalSteps {
     }
 
     public void documentNumberInVC(String documentNumber) throws IOException {
-        String result = JSONPayload.getText();
-        LOGGER.info("result = " + result);
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode jsonNode = objectMapper.readTree(result);
-        JsonNode vcNode = jsonNode.get("vc");
+        JsonNode vcNode = getVCFromJson("vc");
         JsonNode evidenceNode = vcNode.get("drivingPermit");
 
         ObjectReader objectReader =
@@ -449,5 +424,35 @@ public class FraudPageObject extends UniversalSteps {
         secondAddresssvalidToDayField.sendKeys(day);
         secondAddresssvalidToMonthField.sendKeys(month);
         secondAddresssvalidToYearField.sendKeys(year);
+    }
+
+    public void checkPassedInVC(String checkType) throws IOException {
+        JsonNode vcNode = getVCFromJson("vc");
+        JsonNode evidenceNode = vcNode.get("evidence").get(0);
+        JsonNode checkDetailsNode = evidenceNode.get("checkDetails");
+
+        boolean checkTypeInVC =
+                checkDetailsNode.findValues("fraudCheck").stream()
+                        .anyMatch(x -> x.asText().equals(checkType));
+        assertTrue(checkTypeInVC);
+    }
+
+    public void checkFailedInVC(String checkType) throws JsonProcessingException {
+        JsonNode vcNode = getVCFromJson("vc");
+        JsonNode evidenceNode = vcNode.get("evidence").get(0);
+        JsonNode checkDetailsNode = evidenceNode.get("failedCheckDetails");
+
+        boolean checkTypeInVC =
+                checkDetailsNode.findValues("fraudCheck").stream()
+                        .anyMatch(x -> x.asText().equals(checkType));
+        assertTrue(checkTypeInVC);
+    }
+
+    private JsonNode getVCFromJson(String vc) throws JsonProcessingException {
+        String result = JSONPayload.getText();
+        LOGGER.info("result = " + result);
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(result);
+        return jsonNode.get(vc);
     }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
@@ -176,4 +176,15 @@ public class FraudStepDefs extends FraudPageObject {
     public void enterValidFromDate(String day, String month, String year) {
         addValidFromDate(day, month, year);
     }
+
+    @And("^JSON payload should contain checkDetails (.*)$")
+    public void checkDetailsContains(String checkType) throws IOException {
+        checkPassedInVC(checkType);
+    }
+
+    @And("^JSON payload should contain failedCheckDetails (.*)$")
+    public void jsonPayloadShouldContainFailedCheckDetailsField(String checkDetails)
+            throws JsonProcessingException {
+        checkFailedInVC(checkDetails);
+    }
 }

--- a/acceptance-tests/src/test/resources/features/FraudCRI.feature
+++ b/acceptance-tests/src/test/resources/features/FraudCRI.feature
@@ -236,3 +236,148 @@ Feature: Fraud CRI
     Examples:
       | name                    | dob            | ci  | score |
       | ANTHONY ROBERTS         | 25/06/1959     |     |   2   |
+
+  @build-fraud @test1
+  Scenario Outline:Crosscore Authenticate and PEP completed and user is a PEP
+    Given I navigate to the IPV Core Stub
+    And I click the Fraud CRI for the Build environment
+    And I search for user name LINDA DUFF in the Experian table
+    When I click on Edit User link
+    Then I am on Edit User page
+    And I clear existing Date of Birth
+    Then I enter Date of birth as <dob>
+    And I clear existing first name
+    Then I clear existing surname
+    Then I enter name <name>
+    And I submit user updates
+    Then I navigate to the verifiable issuer to check for a Valid response from experian
+    And JSON payload should contain checkDetails impersonation_risk_check
+    And JSON payload should contain checkDetails mortality_check
+    And JSON payload should contain checkDetails identity_theft_check
+    Then JSON payload should contain checkDetails synthetic_identity_check
+    And JSON payload should contain ci <ci> and score <score>
+    And The test is complete and I close the driver
+    Examples:
+      | name                    | dob            |ci  |score|
+      | JAMALA BROWER           | 27/10/1963     |    |2    |
+
+
+  @build-fraud @test
+  Scenario Outline:Crosscore Authenticate and PEP completed and user not PEP
+    Given I navigate to the IPV Core Stub
+    And I click the Fraud CRI for the Build environment
+    And I search for user name LINDA DUFF in the Experian table
+    When I click on Edit User link
+    Then I am on Edit User page
+    And I clear existing Date of Birth
+    Then I enter Date of birth as <dob>
+    And I clear existing first name
+    Then I clear existing surname
+    And I enter name <name>
+    And I submit user updates
+    Then I navigate to the verifiable issuer to check for a Valid response from experian
+    And JSON payload should contain checkDetails impersonation_risk_check
+    And JSON payload should contain checkDetails mortality_check
+    And JSON payload should contain checkDetails identity_theft_check
+    Then JSON payload should contain checkDetails synthetic_identity_check
+    And JSON payload should contain ci <ci> and score <score>
+    And The test is complete and I close the driver
+    Examples:
+      | name                    | dob       | ci| score|
+      | ALBERT PEPS        | 05/10/1943     |P01   | 2     |
+
+
+  @build-fraud @test
+  Scenario Outline: Mortality u-code returned
+    Given I navigate to the IPV Core Stub
+    And I click the Fraud CRI for the Build environment
+    And I search for user name LINDA DUFF in the Experian table
+    When I click on Edit User link
+    Then I am on Edit User page
+    And I clear existing Date of Birth
+    Then I enter Date of birth as <dob>
+    And I clear existing first name
+    And I clear existing surname
+    Then I enter name <name>
+    And I submit user updates
+    Then I navigate to the verifiable issuer to check for a Valid response from experian
+    And JSON payload should contain failedCheckDetails mortality_check
+    And JSON payload should contain failedCheckDetails identity_theft_check
+    Then JSON payload should contain failedCheckDetails synthetic_identity_check
+    And JSON payload should contain ci <ci> and score <score>
+    And The test is complete and I close the driver
+    Examples:
+      | name           | dob              | ci   | score  |
+      | ALBERT GILT    | 05/10/1943       | T02  | 0     |
+
+
+  @build-fraud @test
+  Scenario Outline: Crosscore Authenticate completed and PEP not completed due to error from Experian
+    Given I navigate to the IPV Core Stub
+    And I click the Fraud CRI for the Build environment
+    And I search for user name LINDA DUFF in the Experian table
+    When I click on Edit User link
+    Then I am on Edit User page
+    And I clear existing Date of Birth
+    Then I enter Date of birth as <dob>
+    And I clear existing first name
+    And I clear existing surname
+    Then I enter name <name>
+    And I submit user updates
+    Then I navigate to the verifiable issuer to check for a Valid response from experian
+    And JSON payload should contain failedCheckDetails impersonation_risk_check
+    And JSON payload should contain checkDetails mortality_check
+    And JSON payload should contain checkDetails identity_theft_check
+    Then JSON payload should contain checkDetails synthetic_identity_check
+    And JSON payload should contain ci <ci> and score <score>
+    And The test is complete and I close the driver
+    Examples:
+      | name                         | dob              | ci   | score  |
+      | ALBERT PEP_ERROR_RESPONSE    | 05/10/1943       |      | 1    |
+
+  @build-fraud @test
+  Scenario Outline: Crosscore Authenticate completed and PEP not completed due to technical failure
+    Given I navigate to the IPV Core Stub
+    And I click the Fraud CRI for the Build environment
+    And I search for user name LINDA DUFF in the Experian table
+    When I click on Edit User link
+    Then I am on Edit User page
+    And I clear existing Date of Birth
+    Then I enter Date of birth as <dob>
+    And I clear existing first name
+    And I clear existing surname
+    Then I enter name <name>
+    And I submit user updates
+    Then I navigate to the verifiable issuer to check for a Valid response from experian
+    And JSON payload should contain failedCheckDetails impersonation_risk_check
+    And JSON payload should contain checkDetails mortality_check
+    And JSON payload should contain checkDetails identity_theft_check
+    Then JSON payload should contain checkDetails synthetic_identity_check
+    And JSON payload should contain ci <ci> and score <score>
+    And The test is complete and I close the driver
+    Examples:
+      | name                    | dob              | ci   | score  |
+      | ALBERT PEP_TECH_FAIL    | 05/10/1943       |      | 1    |
+
+  @build-fraud @test
+  Scenario Outline: Decision score below 35
+    Given I navigate to the IPV Core Stub
+    And I click the Fraud CRI for the Build environment
+    And I search for user name LINDA DUFF in the Experian table
+    When I click on Edit User link
+    Then I am on Edit User page
+    And I clear existing Date of Birth
+    Then I enter Date of birth as <dob>
+    And I clear existing first name
+    And I clear existing surname
+    Then I enter name <name>
+    And I submit user updates
+    Then I navigate to the verifiable issuer to check for a Valid response from experian
+    And JSON payload should contain failedCheckDetails mortality_check
+    And JSON payload should contain failedCheckDetails identity_theft_check
+    Then JSON payload should contain failedCheckDetails synthetic_identity_check
+    And JSON payload should contain ci <ci> and score <score>
+    And The test is complete and I close the driver
+    Examples:
+      | name                    | dob              | ci   | score  |
+      | ALBERT NO_FILE_35       | 05/10/1943       |      | 1      |


### PR DESCRIPTION
Create checkDetails and failedcheckDetails component in the Fraud CRI VC

checkDetails | Array | Array of objects for checks that succeeded (partially or completely).
-- | -- | --
failedcheckDetails | Array | JSON array for checks that completely failed.


[LIME-257]

 Lime-257-checkDetails and failedCheckDetails test added to FraudCRI.feature

- [LIME-257](https://govukverify.atlassian.net/browse/LIME-257)

## Checklists
1. Crosscore Authenticate and PEP completed and user not PEP
2. Crosscore Authenticate and PEP completed and user is a PEP
3. Mortality u-code returned
4. Crosscore Authenticate completed and PEP not completed due to error from Experian
5. Crosscore Authenticate completed and PEP not completed due to technical failure
6. Decision score below 35





[LIME-257]: https://govukverify.atlassian.net/browse/LIME-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-257]: https://govukverify.atlassian.net/browse/LIME-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ