### PR TITLE
LIME-419 - Third Party response times recorded in metrics

### DIFF
--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayTest.java
@@ -126,11 +126,10 @@ class ThirdPartyFraudGatewayTest {
         FraudCheckResult actualFraudCheckResult =
                 thirdPartyFraudGateway.performFraudCheck(personIdentity, false);
 
-        InOrder inOrder = inOrder(mockEventProbe);
-        inOrder.verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_CREATED);
-        inOrder.verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_SEND_OK);
-        inOrder.verify(mockEventProbe, times(1))
-                .counterMetric(eq(THIRD_PARTY_FRAUD_RESPONSE_LATENCY), anyDouble());
+        verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_CREATED);
+        verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_SEND_OK);
+        verify(mockEventProbe, times(1))
+                .counterMetric(eq(THIRD_PARTY_FRAUD_RESPONSE_LATENCY_MILLIS), anyDouble());
 
         verify(mockRequestMapper).mapPersonIdentity(personIdentity);
         verify(mockObjectMapper).writeValueAsString(testApiRequest);
@@ -628,11 +627,10 @@ class ThirdPartyFraudGatewayTest {
         FraudCheckResult actualFraudCheckResult =
                 thirdPartyFraudGateway.performFraudCheck(personIdentity, true);
 
-        InOrder inOrder = inOrder(mockEventProbe);
-        inOrder.verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_CREATED);
-        inOrder.verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_SEND_OK);
-        inOrder.verify(mockEventProbe, times(1))
-                .counterMetric(eq(THIRD_PARTY_PEP_RESPONSE_LATENCY), anyDouble());
+        verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_CREATED);
+        verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_SEND_OK);
+        verify(mockEventProbe, times(1))
+                .counterMetric(eq(THIRD_PARTY_PEP_RESPONSE_LATENCY_MILLIS), anyDouble());
 
         verify(mockRequestMapper).mapPEPPersonIdentity(personIdentity);
         verify(mockObjectMapper).writeValueAsString(testApiRequest);

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayTest.java
@@ -38,11 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_REQUEST_CREATED;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_REQUEST_SEND_ERROR;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_REQUEST_SEND_MAX_RETRIES;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_REQUEST_SEND_OK;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_REQUEST_SEND_RETRY;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.*;
 
 @ExtendWith(MockitoExtension.class)
 class ThirdPartyFraudGatewayTest {
@@ -130,8 +126,11 @@ class ThirdPartyFraudGatewayTest {
         FraudCheckResult actualFraudCheckResult =
                 thirdPartyFraudGateway.performFraudCheck(personIdentity, false);
 
-        verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_CREATED);
-        verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_SEND_OK);
+        InOrder inOrder = inOrder(mockEventProbe);
+        inOrder.verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_CREATED);
+        inOrder.verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_SEND_OK);
+        inOrder.verify(mockEventProbe, times(1))
+                .counterMetric(eq(THIRD_PARTY_FRAUD_RESPONSE_LATENCY), anyDouble());
 
         verify(mockRequestMapper).mapPersonIdentity(personIdentity);
         verify(mockObjectMapper).writeValueAsString(testApiRequest);
@@ -629,8 +628,11 @@ class ThirdPartyFraudGatewayTest {
         FraudCheckResult actualFraudCheckResult =
                 thirdPartyFraudGateway.performFraudCheck(personIdentity, true);
 
-        verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_CREATED);
-        verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_SEND_OK);
+        InOrder inOrder = inOrder(mockEventProbe);
+        inOrder.verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_CREATED);
+        inOrder.verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_SEND_OK);
+        inOrder.verify(mockEventProbe, times(1))
+                .counterMetric(eq(THIRD_PARTY_PEP_RESPONSE_LATENCY), anyDouble());
 
         verify(mockRequestMapper).mapPEPPersonIdentity(personIdentity);
         verify(mockObjectMapper).writeValueAsString(testApiRequest);

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/Definitions.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/Definitions.java
@@ -66,9 +66,9 @@ public class Definitions {
             "third_party_pep_response_type_unknown";
 
     // Third Party Response Latency
-    public static final String THIRD_PARTY_FRAUD_RESPONSE_LATENCY =
+    public static final String THIRD_PARTY_FRAUD_RESPONSE_LATENCY_MILLIS =
             "third_party_fraud_response_latency";
-    public static final String THIRD_PARTY_PEP_RESPONSE_LATENCY =
+    public static final String THIRD_PARTY_PEP_RESPONSE_LATENCY_MILLIS =
             "third_party_pep_response_latency";
 
     // IdentityVerificationInfoResponseValidator Fraud

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/Definitions.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/Definitions.java
@@ -65,6 +65,12 @@ public class Definitions {
     public static final String THIRD_PARTY_PEP_RESPONSE_TYPE_UNKNOWN =
             "third_party_pep_response_type_unknown";
 
+    // Third Party Response Latency
+    public static final String THIRD_PARTY_FRAUD_RESPONSE_LATENCY =
+            "third_party_fraud_response_latency";
+    public static final String THIRD_PARTY_PEP_RESPONSE_LATENCY =
+            "third_party_pep_response_latency";
+
     // IdentityVerificationInfoResponseValidator Fraud
     public static final String THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO_VALIDATION_PASS =
             "third_party_fraud_response_type_info_validation_pass";


### PR DESCRIPTION
## Proposed changes

### What changed

- Fraud Check duration metric added to AWS Cloudwatch.
- PEP Check duration metric added to AWS Cloudwatch.

### Issue tracking

- [LIME-419](https://govukverify.atlassian.net/browse/LIME-419)

[LIME-419]: https://govukverify.atlassian.net/browse/LIME-419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="371" alt="image" src="https://user-images.githubusercontent.com/107932230/216579097-1123e0e8-c987-49ee-b875-5ae30e0a86c4.png">