### PR TITLE
LIME-466 - Updating tests to use shared-dev

### DIFF
--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Run API integration tests
         ### currently failing as were running build on dev stack
         env:
-          ENVIRONMENT: dev
+          ENVIRONMENT: shared-dev
           APIGW_API_KEY: ${{ secrets.API_KEY_CRI_DEV }}
           coreStubUrl: ${{ secrets.CORE_STUB_URL }}
           coreStubUsername: ${{ secrets.CORE_STUB_USERNAME }}

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/service/ConfigurationService.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/service/ConfigurationService.java
@@ -86,7 +86,10 @@ public class ConfigurationService {
             throw new IllegalArgumentException(
                     "Environment variable PRIVATE API endpoint is not set");
         }
-        String stage = this.environment.equals("local") ? "dev" : this.environment;
+        String stage =
+                this.environment.equals("local") || this.environment.equals("shared-dev")
+                        ? "dev"
+                        : this.environment;
         LOGGER.info("privateGatewayId =>" + privateGatewayId);
         return "https://" + privateGatewayId + ".execute-api.eu-west-2.amazonaws.com/" + stage;
     }

--- a/acceptance-tests/src/test/resources/features/FraudCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/FraudCRIAPI.feature
@@ -3,7 +3,7 @@ Feature: Fraud CRI API
 
   @intialJWT_happy_path @pre-merge @dev
   Scenario: Acquire initial JWT (STUB)
-    Given user has the user identity in the form of a signed JWT string for CRI Id fraud-cri-dev
+    Given user has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
     When user sends a POST request to session end point
     Then user gets a session-id
 


### PR DESCRIPTION
### What changed

Updating pre-merge-integration workflow and tests to use shared-dev

### Why did it change

To fix pre-merge-integration test github action