### PR TITLE
LIME-468 - Activity History score logging

### DIFF
--- a/.github/workflows/dailySmokeTest.yml
+++ b/.github/workflows/dailySmokeTest.yml
@@ -26,6 +26,10 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
+      - uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.3
+
       - name: Run Fraud Smoke test against build environment
         env:
           BROWSER: chrome-headless

--- a/.github/workflows/gradleBuildTest.yml
+++ b/.github/workflows/gradleBuildTest.yml
@@ -25,6 +25,10 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
+      - uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.3
+
       - name: Run Fraud Smoke test against build environment
         env:
           BROWSER: chrome-headless
@@ -33,5 +37,5 @@ jobs:
           coreStubUsername: ${{ secrets.CORE_STUB_USERNAME }}
           coreStubPassword: ${{ secrets.CORE_STUB_PASSWORD }}
           orchestratorStubUrl: ${{ secrets.orchestratorStubUrl }}
-        run: cd acceptance-tests && gradle fraudCriSmokeBuild
+        run: cd acceptance-tests && ./gradlew fraudCriSmokeBuild
 

--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -32,6 +32,10 @@ jobs:
           java-version: 11
           distribution: zulu
 
+      - uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.3
+
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v1
 

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/AuthConsumer.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/AuthConsumer.java
@@ -1,0 +1,32 @@
+package uk.gov.di.ipv.cri.fraud.api.gateway.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AuthConsumer {
+
+    @JsonProperty("locDataOnlyAtCLoc")
+    private LocDataOnlyAtCLoc locDataOnlyAtCLoc;
+
+    @JsonProperty("idandLocDataAtCL")
+    private IDandLocDataAtCL idandLocDataAtCL;
+
+    public LocDataOnlyAtCLoc getLocDataOnlyAtCLoc() {
+        return locDataOnlyAtCLoc;
+    }
+
+    public void setLocDataOnlyAtCLoc(LocDataOnlyAtCLoc locDataOnlyAtCLoc) {
+        this.locDataOnlyAtCLoc = locDataOnlyAtCLoc;
+    }
+
+    public IDandLocDataAtCL getIdandLocDataAtCL() {
+        return idandLocDataAtCL;
+    }
+
+    public void setIdandLocDataAtCL(IDandLocDataAtCL idandLocDataAtCL) {
+        this.idandLocDataAtCL = idandLocDataAtCL;
+    }
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/AuthPlusResults.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/AuthPlusResults.java
@@ -1,0 +1,21 @@
+package uk.gov.di.ipv.cri.fraud.api.gateway.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AuthPlusResults {
+
+    @JsonProperty("authConsumer")
+    private AuthConsumer authConsumer;
+
+    public AuthConsumer getAuthConsumer() {
+        return authConsumer;
+    }
+
+    public void setAuthConsumer(AuthConsumer authConsumer) {
+        this.authConsumer = authConsumer;
+    }
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/AuthResults.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/AuthResults.java
@@ -1,0 +1,21 @@
+package uk.gov.di.ipv.cri.fraud.api.gateway.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AuthResults {
+
+    @JsonProperty("authPlusResults")
+    private AuthPlusResults authPlusResults;
+
+    public AuthPlusResults getAuthPlusResults() {
+        return authPlusResults;
+    }
+
+    public void setAuthPlusResults(AuthPlusResults authPlusResults) {
+        this.authPlusResults = authPlusResults;
+    }
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/DecisionElement.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/DecisionElement.java
@@ -8,9 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonIgnoreProperties(
-        ignoreUnknown = true,
-        value = {"otherData"})
+@JsonIgnoreProperties(ignoreUnknown = true)
+//        value = {"otherData"})
 public class DecisionElement {
 
     @JsonProperty("serviceName")

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/IDandLocDataAtCL.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/IDandLocDataAtCL.java
@@ -1,0 +1,32 @@
+package uk.gov.di.ipv.cri.fraud.api.gateway.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IDandLocDataAtCL {
+
+    @JsonProperty("startDateOldestPrim")
+    private String startDateOldestPrim;
+
+    @JsonProperty("startDateOldestSec")
+    private String startDateOldestSec;
+
+    public String getStartDateOldestPrim() {
+        return startDateOldestPrim;
+    }
+
+    public void setStartDateOldestPrim(String startDateOldestPrim) {
+        this.startDateOldestPrim = startDateOldestPrim;
+    }
+
+    public String getStartDateOldestSec() {
+        return startDateOldestSec;
+    }
+
+    public void setStartDateOldestSec(String startDateOldestSec) {
+        this.startDateOldestSec = startDateOldestSec;
+    }
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/LocDataOnlyAtCLoc.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/LocDataOnlyAtCLoc.java
@@ -1,0 +1,21 @@
+package uk.gov.di.ipv.cri.fraud.api.gateway.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LocDataOnlyAtCLoc {
+
+    @JsonProperty("startDateOldestPrim")
+    private String startDateOldestPrim;
+
+    public String getStartDateOldestPrim() {
+        return startDateOldestPrim;
+    }
+
+    public void setStartDateOldestPrim(String startDateOldestPrim) {
+        this.startDateOldestPrim = startDateOldestPrim;
+    }
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/OtherData.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/OtherData.java
@@ -1,13 +1,26 @@
 package uk.gov.di.ipv.cri.fraud.api.gateway.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OtherData {
 
     @JsonProperty("response")
     private String response;
+
+    @JsonProperty("authResults")
+    private AuthResults authResults;
+
+    public AuthResults getAuthResults() {
+        return authResults;
+    }
+
+    public void setAuthResults(AuthResults authResults) {
+        this.authResults = authResults;
+    }
 
     public String getResponse() {
         return response;

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java
@@ -206,6 +206,23 @@ public class TestDataCreator {
         decisionElement1.setDecisionReason("TEST");
         decisionElement1.setAppReference("UNIT_TEST");
 
+        OtherData otherData = new OtherData();
+        AuthResults authResults = new AuthResults();
+        AuthPlusResults authPlusResults = new AuthPlusResults();
+        AuthConsumer authConsumer = new AuthConsumer();
+        IDandLocDataAtCL iDandLocDataAtCL = new IDandLocDataAtCL();
+        LocDataOnlyAtCLoc locDataOnlyAtCLoc = new LocDataOnlyAtCLoc();
+
+        locDataOnlyAtCLoc.setStartDateOldestPrim("201510");
+        iDandLocDataAtCL.setStartDateOldestSec("201512");
+        iDandLocDataAtCL.setStartDateOldestPrim("201212");
+
+        authConsumer.setIdandLocDataAtCL(iDandLocDataAtCL);
+        authConsumer.setLocDataOnlyAtCLoc(locDataOnlyAtCLoc);
+        authPlusResults.setAuthConsumer(authConsumer);
+        authResults.setAuthPlusResults(authPlusResults);
+        otherData.setAuthResults(authResults);
+
         List<Rule> rules = new ArrayList<>();
         Rule rule1 = new Rule();
         rule1.setRuleName("AUTP_IDCONFLEVEL");
@@ -215,6 +232,7 @@ public class TestDataCreator {
 
         rules.add(rule1);
         decisionElement1.setRules(rules);
+        decisionElement1.setOtherData(otherData);
 
         decisionElements.add(decisionElement1);
         payload.setDecisionElements(decisionElements);
@@ -276,6 +294,23 @@ public class TestDataCreator {
         decisionElement1.setDecisionReason("TEST");
         decisionElement1.setAppReference("UNIT_TEST");
 
+        OtherData otherData = new OtherData();
+        AuthResults authResults = new AuthResults();
+        AuthPlusResults authPlusResults = new AuthPlusResults();
+        AuthConsumer authConsumer = new AuthConsumer();
+        IDandLocDataAtCL iDandLocDataAtCL = new IDandLocDataAtCL();
+        LocDataOnlyAtCLoc locDataOnlyAtCLoc = new LocDataOnlyAtCLoc();
+
+        locDataOnlyAtCLoc.setStartDateOldestPrim("201510");
+        iDandLocDataAtCL.setStartDateOldestSec("201512");
+        iDandLocDataAtCL.setStartDateOldestPrim("201212");
+
+        authConsumer.setIdandLocDataAtCL(iDandLocDataAtCL);
+        authConsumer.setLocDataOnlyAtCLoc(locDataOnlyAtCLoc);
+        authPlusResults.setAuthConsumer(authConsumer);
+        authResults.setAuthPlusResults(authPlusResults);
+        otherData.setAuthResults(authResults);
+
         List<Rule> rules = new ArrayList<>();
         Rule rule1 = new Rule();
         rule1.setRuleName("AUTP_IDCONFLEVEL");
@@ -285,6 +320,7 @@ public class TestDataCreator {
 
         rules.add(rule1);
         decisionElement1.setRules(rules);
+        decisionElement1.setOtherData(otherData);
 
         decisionElements.add(decisionElement1);
         payload.setDecisionElements(decisionElements);


### PR DESCRIPTION
### What changed

Added logging of Activity History score related fields found in third party responses for use in Activity history score calculation.

### Why did it change

To determine what we get sent back in the fields so that we can appropriately calculate activity history score