### PR TITLE
LIME-473 - Replacing CIs with thirdPartyFraudCodes in auditEvents

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/IdentityVerificationResult.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/IdentityVerificationResult.java
@@ -12,6 +12,7 @@ public class IdentityVerificationResult {
     private String transactionId;
     private String pepTransactionId;
     private String decisionScore;
+    private List<String> thirdPartyFraudCodes = new ArrayList<>();
 
     // These checks have specific meanings and appear in the VC
     private List<String> checksSucceeded = new ArrayList<>();
@@ -95,5 +96,13 @@ public class IdentityVerificationResult {
 
     public void setChecksFailed(List<String> checksFailed) {
         this.checksFailed = checksFailed;
+    }
+
+    public List<String> getThirdPartyFraudCodes() {
+        return thirdPartyFraudCodes;
+    }
+
+    public void setThirdPartyFraudCodes(List<String> thirdPartyFraudCodes) {
+        this.thirdPartyFraudCodes = thirdPartyFraudCodes;
     }
 }

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/audit/ExperianCrossCoreResponse.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/audit/ExperianCrossCoreResponse.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.cri.fraud.api.domain.audit;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Objects;
 
 public class ExperianCrossCoreResponse {
 
@@ -15,5 +16,18 @@ public class ExperianCrossCoreResponse {
 
     public List<String> getuCodes() {
         return uCodes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ExperianCrossCoreResponse that = (ExperianCrossCoreResponse) o;
+        return Objects.equals(uCodes, that.uCodes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uCodes);
     }
 }

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/audit/TPREFraudAuditExtension.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/audit/TPREFraudAuditExtension.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.cri.fraud.api.domain.audit;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Objects;
 
 public class TPREFraudAuditExtension {
     @JsonProperty("experianCrossCoreResponse")
@@ -14,5 +15,18 @@ public class TPREFraudAuditExtension {
 
     public ExperianCrossCoreResponse getExperianCrossCoreResponse() {
         return experianCrossCoreResponse;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TPREFraudAuditExtension that = (TPREFraudAuditExtension) o;
+        return Objects.equals(experianCrossCoreResponse, that.experianCrossCoreResponse);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(experianCrossCoreResponse);
     }
 }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/CredentialHandlerTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/CredentialHandlerTest.java
@@ -120,7 +120,7 @@ class CredentialHandlerTest {
         assertNotNull(responseEvent);
         assertEquals(200, responseEvent.getStatusCode());
         assertEquals(
-                "{\"success\":true,\"validationErrors\":null,\"error\":null,\"contraIndicators\":[\"A01\"],\"identityCheckScore\":1,\"transactionId\":null,\"pepTransactionId\":null,\"decisionScore\":\"90\",\"checksSucceeded\":[\"check_one\",\"check_two\",\"check_three\"],\"checksFailed\":[]}",
+                "{\"success\":true,\"validationErrors\":null,\"error\":null,\"contraIndicators\":[\"A01\"],\"identityCheckScore\":1,\"transactionId\":null,\"pepTransactionId\":null,\"decisionScore\":\"90\",\"thirdPartyFraudCodes\":[],\"checksSucceeded\":[\"check_one\",\"check_two\",\"check_three\"],\"checksFailed\":[]}",
                 responseEvent.getBody());
     }
 

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.domain.AuditEventContext;
+import uk.gov.di.ipv.cri.common.library.domain.AuditEventType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.common.library.exception.SqsException;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
@@ -17,6 +19,7 @@ import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.fraud.api.domain.FraudCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.domain.IdentityVerificationResult;
 import uk.gov.di.ipv.cri.fraud.api.domain.ValidationResult;
+import uk.gov.di.ipv.cri.fraud.api.domain.audit.TPREFraudAuditExtension;
 import uk.gov.di.ipv.cri.fraud.api.gateway.ThirdPartyFraudGateway;
 import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
 
@@ -28,6 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -330,6 +335,12 @@ class IdentityVerificationServiceTest {
             assertAllFraudChecksFailAndPepNotPresent(
                     result.getChecksSucceeded(), result.getChecksFailed());
         }
+
+        verify(mockAuditService)
+                .sendAuditEvent(
+                        eq(AuditEventType.RESPONSE_RECEIVED),
+                        any(AuditEventContext.class),
+                        eq(new TPREFraudAuditExtension(result.getThirdPartyFraudCodes())));
 
         assertEquals(expectedIdentityFraudScore, result.getIdentityCheckScore());
     }


### PR DESCRIPTION
### What changed

Replaced CIs with thirdPartyFraudCodes in THIRD_PARTY_REQUEST_RECEIVED audit event
