### PR TITLE
LIME-415 Fraud CRI API tests

### DIFF
--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -56,10 +56,13 @@ jobs:
       - name: SAM deploy integration test stack
         run: |
           STACK_NAME=${{ env.STACK_NAME_PREFIX }}-${{ steps.vars.outputs.sha_short }}
+          aws ssm put-parameter --name "/${STACK_NAME}/contraindicationMappings" --type "String" --value "${{ secrets.SENSTIVE_PARAM_CI_MAPPINGS }}" 2>&1 > /dev/null
+          aws ssm put-parameter --name "/${STACK_NAME}/zeroScoreUcodes" --type "String" --value "${{ secrets.SENSTIVE_PARAM_ZERO_SCORE_CODES }}" 2>&1 > /dev/null
+          aws ssm put-parameter --name "/${STACK_NAME}/noFileFoundThreshold" --type "String" --value "${{ secrets.SENSTIVE_PARAM_FILE_NOT_FOUND_THRESHOLD }}" 2>&1 > /dev/null
           sam deploy \
             --no-fail-on-empty-changeset \
             --no-confirm-changeset \
-            --parameter-overrides "Environment=${{ env.ENVIRONMENT }} CodeSigningEnabled=false AuditEventNamePrefix=/common-cri-parameters/FraudAuditEventNamePrefix CriIdentifier=/common-cri-parameters/FraudCriIdentifier CommonStackName=fraud-common-cri-api" \
+            --parameter-overrides "Environment=${{ secrets.SHARED_DEV_ENVIRONMENT }} CodeSigningEnabled=false AuditEventNamePrefix=/common-cri-parameters/FraudAuditEventNamePrefix CriIdentifier=/common-cri-parameters/FraudCriIdentifier CommonStackName=fraud-common-cri-api" \
             --stack-name $STACK_NAME \
             --s3-bucket ${{ secrets.AWS_CONFIG_BUCKET }} \
             --s3-prefix $STACK_NAME \
@@ -87,5 +90,8 @@ jobs:
         if: always()
         run: |
           STACK_NAME=${{ env.STACK_NAME_PREFIX }}-${{ steps.vars.outputs.sha_short }}
+          aws ssm delete-parameter --name "/${STACK_NAME}/contraindicationMappings" 2>&1 > /dev/null
+          aws ssm delete-parameter --name "/${STACK_NAME}/zeroScoreUcodes" 2>&1 > /dev/null
+          aws ssm delete-parameter --name "/${STACK_NAME}/noFileFoundThreshold" 2>&1 > /dev/null
           aws cloudformation delete-stack --region ${{ env.AWS_REGION }} --stack-name $STACK_NAME
 

--- a/acceptance-tests/run-local-tests.sh
+++ b/acceptance-tests/run-local-tests.sh
@@ -66,6 +66,10 @@ if [[ "${BACKEND}" =~ "yes" ]]; then
   API_GATEWAY_ID_PRIVATE=$([ -z "$API_GATEWAY_ID_PRIVATE_NEW" ] && echo "$API_GATEWAY_ID_PRIVATE" || echo "$API_GATEWAY_ID_PRIVATE_NEW")
   export API_GATEWAY_ID_PRIVATE=$API_GATEWAY_ID_PRIVATE
 
+  read -p "Enter the public gateway id? [previous=$API_GATEWAY_ID_PUBLIC] " API_GATEWAY_ID_PUBLIC_NEW
+
+  API_GATEWAY_ID_PUBLIC=$([ -z "$API_GATEWAY_ID_PUBLIC_NEW" ] && echo "$API_GATEWAY_ID_PUBLIC" || echo "$API_GATEWAY_ID_PUBLIC_NEW")
+  export API_GATEWAY_ID_PUBLIC=$API_GATEWAY_ID_PUBLIC
 fi
 
 ###### Remove previous config and set with new values
@@ -82,6 +86,7 @@ echo "LOCAL=${LOCAL}" >> test-args.conf
 echo "E2E=${E2E}" >> test-args.conf
 echo "BACKEND=${BACKEND}" >> test-args.conf
 echo "API_GATEWAY_ID_PRIVATE=${API_GATEWAY_ID_PRIVATE}" >> test-args.conf
+echo "API_GATEWAY_ID_PUBLIC=${API_GATEWAY_ID_PUBLIC}" >> test-args.conf
 echo "TAG=${TAG}" >> test-args.conf
 
 

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/model/AuthorisationResponse.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/model/AuthorisationResponse.java
@@ -1,0 +1,53 @@
+package gov.di_ipv_fraud.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AuthorisationResponse {
+
+    private State state;
+    private String issuer;
+    private String accessToken;
+    private AuthorizationCode authorizationCode;
+    private String redirectionURI;
+
+    public State getState() {
+        return state;
+    }
+
+    public void setState(State state) {
+        this.state = state;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public AuthorizationCode getAuthorizationCode() {
+        return authorizationCode;
+    }
+
+    public void setAuthorizationCode(AuthorizationCode authorizationCode) {
+        this.authorizationCode = authorizationCode;
+    }
+
+    public String getRedirectionURI() {
+        return redirectionURI;
+    }
+
+    public void setRedirectionURI(String redirectionURI) {
+        this.redirectionURI = redirectionURI;
+    }
+}

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/model/AuthorizationCode.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/model/AuthorizationCode.java
@@ -1,0 +1,14 @@
+package gov.di_ipv_fraud.model;
+
+public class AuthorizationCode {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/model/State.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/model/State.java
@@ -1,0 +1,14 @@
+package gov.di_ipv_fraud.model;
+
+public class State {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudAPIPage.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudAPIPage.java
@@ -1,10 +1,15 @@
 package gov.di_ipv_fraud.pages;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.nimbusds.jwt.SignedJWT;
+import gov.di_ipv_fraud.model.AuthorisationResponse;
 import gov.di_ipv_fraud.service.ConfigurationService;
 import gov.di_ipv_fraud.step_definitions.FraudAPIStepDefs;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
 
 import java.io.IOException;
 import java.net.URI;
@@ -12,6 +17,7 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.text.ParseException;
 import java.util.Base64;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -22,6 +28,9 @@ public class FraudAPIPage {
 
     private static String SESSION_REQUEST_BODY;
     private static String SESSION_ID;
+    private static String STATE;
+    private static String AUTHCODE;
+    private static String ACCESS_TOKEN;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final int LindaDuffExperianRowNumber = 6;
 
@@ -29,16 +38,41 @@ public class FraudAPIPage {
             new ConfigurationService(System.getenv("ENVIRONMENT"));
     private static final Logger LOGGER = Logger.getLogger(FraudAPIStepDefs.class.getName());
 
-    public void userIdentityAsJwtString(String criId)
+    public String getAuthorisationJwtFromStub(String criId)
             throws URISyntaxException, IOException, InterruptedException {
         String coreStubUrl = configurationService.getCoreStubUrl(false);
-
         if (coreStubUrl == null) {
             throw new IllegalArgumentException("Environment variable IPV_CORE_STUB_URL is not set");
         }
+        return getClaimsForUser(coreStubUrl, criId, LindaDuffExperianRowNumber);
+    }
 
-        String jsonString = getClaimsForUser(coreStubUrl, criId, LindaDuffExperianRowNumber);
+    public void userIdentityAsJwtString(String criId)
+            throws URISyntaxException, IOException, InterruptedException {
+        String jsonString = getAuthorisationJwtFromStub(criId);
+        LOGGER.info("jsonString = " + jsonString);
+        String coreStubUrl = configurationService.getCoreStubUrl(false);
         SESSION_REQUEST_BODY = createRequest(coreStubUrl, criId, jsonString);
+        LOGGER.info("SESSION_REQUEST_BODY = " + SESSION_REQUEST_BODY);
+    }
+
+    public void userIdentityAsJwtStringForupdatedUser(
+            String givenName, String familyName, String criId)
+            throws URISyntaxException, IOException, InterruptedException {
+        String jsonString = getAuthorisationJwtFromStub(criId);
+        LOGGER.info("jsonString = " + jsonString);
+        String coreStubUrl = configurationService.getCoreStubUrl(false);
+        JsonNode jsonNode = objectMapper.readTree((jsonString));
+        JsonNode nameArray = jsonNode.get("shared_claims").get("name");
+        JsonNode firstItemInNameArray = nameArray.get(0);
+        JsonNode namePartsNode = firstItemInNameArray.get("nameParts");
+        JsonNode firstItemInNamePartsArray = namePartsNode.get(0);
+        ((ObjectNode) firstItemInNamePartsArray).put("value", givenName);
+        JsonNode secondItemInNamePartsArray = namePartsNode.get(1);
+        ((ObjectNode) secondItemInNamePartsArray).put("value", familyName);
+        String updatedJsonString = jsonNode.toString();
+        LOGGER.info("updatedJsonString = " + updatedJsonString);
+        SESSION_REQUEST_BODY = createRequest(coreStubUrl, criId, updatedJsonString);
         LOGGER.info("SESSION_REQUEST_BODY = " + SESSION_REQUEST_BODY);
     }
 
@@ -58,11 +92,115 @@ public class FraudAPIPage {
         Map<String, String> deserialisedResponse =
                 objectMapper.readValue(sessionResponse, new TypeReference<>() {});
         SESSION_ID = deserialisedResponse.get("session_id");
+        STATE = deserialisedResponse.get("state");
     }
 
     public void getSessionId() {
         LOGGER.info("SESSION_ID = " + SESSION_ID);
         assertTrue(StringUtils.isNotBlank(SESSION_ID));
+    }
+
+    public void postRequestToFraudEndpoint() throws IOException, InterruptedException {
+        String privateApiGatewayUrl = configurationService.getPrivateAPIEndpoint();
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(URI.create(privateApiGatewayUrl + "/identity-check"))
+                        .setHeader("Accept", "application/json")
+                        .setHeader("Content-Type", "application/json")
+                        .setHeader("session_id", SESSION_ID)
+                        .POST(HttpRequest.BodyPublishers.ofString(""))
+                        .build();
+        String fraudCheckResponse = sendHttpRequest(request).body();
+        LOGGER.info("fraudCheckResponse = " + fraudCheckResponse);
+    }
+
+    public void getAuthorisationCode() throws IOException, InterruptedException {
+        String privateApiGatewayUrl = configurationService.getPrivateAPIEndpoint();
+        String coreStubUrl = configurationService.getCoreStubUrl(false);
+
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(
+                                URI.create(
+                                        privateApiGatewayUrl
+                                                + "/authorization?redirect_uri="
+                                                + coreStubUrl
+                                                + "/callback&state="
+                                                + STATE
+                                                + "&scope=openid&response_type=code&client_id=ipv-core-stub"))
+                        .setHeader("Accept", "application/json")
+                        .setHeader("Content-Type", "application/json")
+                        .setHeader("session-id", SESSION_ID)
+                        .GET()
+                        .build();
+        String authCallResponse = sendHttpRequest(request).body();
+        LOGGER.info("authCallResponse = " + authCallResponse);
+        AuthorisationResponse deserialisedResponse =
+                objectMapper.readValue(authCallResponse, AuthorisationResponse.class);
+        AUTHCODE = deserialisedResponse.getAuthorizationCode().getValue();
+        LOGGER.info("authorizationCode = " + AUTHCODE);
+    }
+
+    public void postRequestToAccessTokenEndpoint(String criId)
+            throws IOException, InterruptedException {
+        String accessTokenRequestBody = getAccessTokenRequest(criId);
+        LOGGER.info("Access Token Request Body = " + accessTokenRequestBody);
+        String publicApiGatewayUrl = configurationService.getPublicAPIEndpoint();
+        LOGGER.info("getPublicAPIEndpoint() ==> " + publicApiGatewayUrl);
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(URI.create(publicApiGatewayUrl + "/token"))
+                        .setHeader("Accept", "application/json")
+                        .setHeader("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(accessTokenRequestBody))
+                        .build();
+        String accessTokenPostCallResponse = sendHttpRequest(request).body();
+        LOGGER.info("accessTokenPostCallResponse = " + accessTokenPostCallResponse);
+        Map<String, String> deserialisedResponse =
+                objectMapper.readValue(accessTokenPostCallResponse, new TypeReference<>() {});
+        ACCESS_TOKEN = deserialisedResponse.get("access_token");
+    }
+
+    public String requestFraudCRIVC() throws IOException, InterruptedException, ParseException {
+        String publicApiGatewayUrl = configurationService.getPublicAPIEndpoint();
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(URI.create(publicApiGatewayUrl + "/credential/issue"))
+                        .setHeader("Accept", "application/json")
+                        .setHeader("Content-Type", "application/json")
+                        .setHeader("Authorization", "Bearer " + ACCESS_TOKEN)
+                        .POST(HttpRequest.BodyPublishers.ofString(""))
+                        .build();
+        String requestFraudVCResponse = sendHttpRequest(request).body();
+        LOGGER.info("requestFraudVCResponse = " + requestFraudVCResponse);
+        SignedJWT signedJWT = SignedJWT.parse(requestFraudVCResponse);
+        return signedJWT.getJWTClaimsSet().toString();
+    }
+
+    public void ciAndIdentityFraudScoreInVC(String ci, Integer identityFraudScore)
+            throws URISyntaxException, IOException, InterruptedException, ParseException {
+        String fraudCRIVC = requestFraudCRIVC();
+        LOGGER.info("fraudCRIVC = " + fraudCRIVC);
+        JsonNode jsonNode = objectMapper.readTree((fraudCRIVC));
+        JsonNode evidenceArray = jsonNode.get("vc").get("evidence");
+        JsonNode firstItemInEvidenceArray = evidenceArray.get(0);
+        LOGGER.info("firstItemInEvidenceArray = " + firstItemInEvidenceArray);
+        JsonNode ciNode = firstItemInEvidenceArray.get("ci");
+        if (ciNode.isArray() && ciNode.size() > 0) {
+            JsonNode firstItemInCIArray = firstItemInEvidenceArray.get("ci").get(0);
+            String actualCI = firstItemInCIArray.asText();
+            LOGGER.info("actualCI = " + actualCI);
+            Assert.assertEquals(ci, actualCI);
+        } else {
+            String actualCI = ciNode.asText();
+            LOGGER.info("CI when Empty = " + actualCI);
+            Assert.assertEquals(ci, actualCI);
+        }
+
+        Integer actualIdentityFraudScore =
+                firstItemInEvidenceArray.get("identityFraudScore").asInt();
+        LOGGER.info("actualIdentityFraudScore = " + actualIdentityFraudScore);
+        Assert.assertEquals(identityFraudScore, actualIdentityFraudScore);
     }
 
     private String getClaimsForUser(String baseUrl, String criId, int userDataRowNumber)
@@ -95,7 +233,6 @@ public class FraudAPIPage {
             throws URISyntaxException, IOException, InterruptedException {
 
         URI uri = new URI(baseUrl + "/backend/createSessionRequest?cri=" + criId);
-        LOGGER.info("jsonString = " + jsonString);
         HttpRequest request =
                 HttpRequest.newBuilder()
                         .uri(uri)
@@ -122,5 +259,29 @@ public class FraudAPIPage {
     private static final String getBasicAuthenticationHeader(String username, String password) {
         String valueToEncode = username + ":" + password;
         return "Basic " + Base64.getEncoder().encodeToString(valueToEncode.getBytes());
+    }
+
+    private String getAccessTokenRequest(String criId) throws IOException, InterruptedException {
+        String coreStubUrl = configurationService.getCoreStubUrl(false);
+
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(
+                                URI.create(
+                                        coreStubUrl
+                                                + "/backend/createTokenRequestPrivateKeyJWT?authorization_code="
+                                                + AUTHCODE
+                                                + "&cri="
+                                                + criId))
+                        .setHeader("Accept", "application/json")
+                        .setHeader("Content-Type", "application/json")
+                        .setHeader(
+                                "Authorization",
+                                getBasicAuthenticationHeader(
+                                        configurationService.getCoreStubUsername(),
+                                        configurationService.getCoreStubPassword()))
+                        .GET()
+                        .build();
+        return sendHttpRequest(request).body();
     }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/service/ConfigurationService.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/service/ConfigurationService.java
@@ -108,9 +108,12 @@ public class ConfigurationService {
         String publicGatewayId = this.publicApiGatewayId;
         if (publicGatewayId == null) {
             throw new IllegalArgumentException(
-                    "Environment variable PRIVATE API endpoint is not set");
+                    "Environment variable PUBLIC API endpoint is not set");
         }
-        String stage = this.environment.equals("local") ? "dev" : this.environment;
+        String stage =
+                this.environment.equals("local") || this.environment.equals("shared-dev")
+                        ? "dev"
+                        : this.environment;
         LOGGER.info("publicGatewayId =>" + publicGatewayId);
         return "https://" + publicGatewayId + ".execute-api.eu-west-2.amazonaws.com/" + stage;
     }

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/service/ConfigurationService.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/service/ConfigurationService.java
@@ -19,6 +19,7 @@ public class ConfigurationService {
     private final String orchestratorStubUrl;
     private final String privateApiGatewayId;
     private final String environment;
+    private final String publicApiGatewayId;
 
     public ConfigurationService(String env) {
 
@@ -33,6 +34,7 @@ public class ConfigurationService {
         this.passportCriUrl = getParameter("passportCriUrl");
         this.orchestratorStubUrl = getParameter("orchestratorStubUrl");
         this.privateApiGatewayId = getParameter("API_GATEWAY_ID_PRIVATE");
+        this.publicApiGatewayId = getParameter("API_GATEWAY_ID_PUBLIC");
         this.environment = env;
     }
 
@@ -100,5 +102,16 @@ public class ConfigurationService {
             throw new IllegalArgumentException("Environment variable ENVIRONMENT is not set");
         }
         return fraudCRITestEnvironment;
+    }
+
+    public String getPublicAPIEndpoint() {
+        String publicGatewayId = this.publicApiGatewayId;
+        if (publicGatewayId == null) {
+            throw new IllegalArgumentException(
+                    "Environment variable PRIVATE API endpoint is not set");
+        }
+        String stage = this.environment.equals("local") ? "dev" : this.environment;
+        LOGGER.info("publicGatewayId =>" + publicGatewayId);
+        return "https://" + publicGatewayId + ".execute-api.eu-west-2.amazonaws.com/" + stage;
     }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudAPIStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudAPIStepDefs.java
@@ -1,12 +1,14 @@
 package gov.di_ipv_fraud.step_definitions;
 
 import gov.di_ipv_fraud.pages.*;
+import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.text.ParseException;
 
 public class FraudAPIStepDefs extends FraudAPIPage {
 
@@ -16,14 +18,49 @@ public class FraudAPIStepDefs extends FraudAPIPage {
         userIdentityAsJwtString(criId);
     }
 
-    @When("user sends a POST request to session end point")
+    @Given(
+            "user (.*) (.*) has the user identity in the form of a signed JWT string for CRI Id (.*)$")
+    public void user_has_the_user_identity_in_the_form_of_a_signed_jwt_string(
+            String GivenName, String FamilyName, String criId)
+            throws URISyntaxException, IOException, InterruptedException {
+        userIdentityAsJwtStringForupdatedUser(GivenName, FamilyName, criId);
+    }
+
+    @And("user sends a POST request to session endpoint")
     public void user_sends_a_post_request_to_session_end_point()
             throws IOException, InterruptedException {
         postRequestToSessionEndpoint();
     }
 
-    @Then("user gets a session-id")
+    @And("user gets a session-id")
     public void user_gets_a_session_id() {
         getSessionId();
+    }
+
+    @When("user sends a POST request to Fraud endpoint")
+    public void user_sends_a_post_request_to_fraud_end_point()
+            throws IOException, InterruptedException {
+        postRequestToFraudEndpoint();
+    }
+
+    @And("user gets authorisation code")
+    public void user_gets_authorisation_code() throws IOException, InterruptedException {
+        getAuthorisationCode();
+    }
+
+    @And("user sends a POST request to Access Token endpoint (.*)$")
+    public void user_requests_access_token(String CRIId) throws IOException, InterruptedException {
+        postRequestToAccessTokenEndpoint(CRIId);
+    }
+
+    @Then("user requests Fraud CRI VC")
+    public void user_requests_vc() throws IOException, InterruptedException, ParseException {
+        requestFraudCRIVC();
+    }
+
+    @And("VC should contain ci (.*) and identityFraudScore (.*)$")
+    public void vc_should_contain_ci_and_identityFraudScore(String ci, Integer identityFraudScore)
+            throws IOException, InterruptedException, ParseException, URISyntaxException {
+        ciAndIdentityFraudScoreInVC(ci, identityFraudScore);
     }
 }

--- a/acceptance-tests/src/test/resources/features/FraudCRI.feature
+++ b/acceptance-tests/src/test/resources/features/FraudCRI.feature
@@ -94,7 +94,6 @@ Feature: Fraud CRI
     And JSON payload should contain ci A01 and score 2
     And The test is complete and I close the driver
 
-  # User with surname CI6 will return the U015 code and will return CI as P01 in the VC
   @pep_test_all_users @build-fraud
   Scenario Outline: Edit User Happy Path with pep CI (STUB)
     Given I navigate to the IPV Core Stub

--- a/acceptance-tests/src/test/resources/features/FraudCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/FraudCRIAPI.feature
@@ -3,79 +3,79 @@ Feature: Fraud CRI API
 
   @intialJWT_happy_path @fraudCRI_API @pre-merge @dev
   Scenario: Acquire initial JWT and Fraud Check with PEP error response failure(STUB)
-    Given user ALBERT PEP_ERROR_RESPONSE has the user identity in the form of a signed JWT string for CRI Id fraud-cri-dev
+    Given user ALBERT PEP_ERROR_RESPONSE has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
     And user sends a POST request to session endpoint
     And user gets a session-id
     When user sends a POST request to Fraud endpoint
     And user gets authorisation code
-    And user sends a POST request to Access Token endpoint fraud-cri-dev
+    And user sends a POST request to Access Token endpoint fraud-cri-shared-dev
     Then user requests Fraud CRI VC
     And VC should contain ci  and identityFraudScore 1
 
   @fraudCRI_API @pre-merge @dev
   Scenario: Acquire initial JWT and Fraud Check with PEP tech failure(STUB)
-    Given user ALBERT PEP_TECH_FAIL has the user identity in the form of a signed JWT string for CRI Id fraud-cri-dev
+    Given user ALBERT PEP_TECH_FAIL has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
     And user sends a POST request to session endpoint
     And user gets a session-id
     When user sends a POST request to Fraud endpoint
     And user gets authorisation code
-    And user sends a POST request to Access Token endpoint fraud-cri-dev
+    And user sends a POST request to Access Token endpoint fraud-cri-shared-dev
     Then user requests Fraud CRI VC
     And VC should contain ci  and identityFraudScore 1
 
   @fraudCRI_API @pre-merge @dev
   Scenario: Fraud Check Succeeds and PEP Succeeds but is not PEP (HOLLINGDALU)
-    Given user ALBERT HOLLINGDALU has the user identity in the form of a signed JWT string for CRI Id fraud-cri-dev
+    Given user ALBERT HOLLINGDALU has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
     And user sends a POST request to session endpoint
     And user gets a session-id
     When user sends a POST request to Fraud endpoint
     And user gets authorisation code
-    And user sends a POST request to Access Token endpoint fraud-cri-dev
+    And user sends a POST request to Access Token endpoint fraud-cri-shared-dev
     Then user requests Fraud CRI VC
     And VC should contain ci  and identityFraudScore 2
 
   @fraudCRI_API @pre-merge @dev
   Scenario: Fraud Check and PEP check complete(STUB)
 #    VC for Fraud Succeeds and PEP Succeeds but is PEP (PEPS)
-    Given user ALBERT PEPS has the user identity in the form of a signed JWT string for CRI Id fraud-cri-dev
+    Given user ALBERT PEPS has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
     And user sends a POST request to session endpoint
     And user gets a session-id
     When user sends a POST request to Fraud endpoint
     And user gets authorisation code
-    And user sends a POST request to Access Token endpoint fraud-cri-dev
+    And user sends a POST request to Access Token endpoint fraud-cri-shared-dev
     Then user requests Fraud CRI VC
     And VC should contain ci P01 and identityFraudScore 2
 
   @fraudCRI_API @pre-merge @dev
   Scenario: Fraud Happy path for user with decision score below 35(STUB)
-    Given user ALBERT NO_FILE_35 has the user identity in the form of a signed JWT string for CRI Id fraud-cri-dev
+    Given user ALBERT NO_FILE_35 has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
     And user sends a POST request to session endpoint
     And user gets a session-id
     When user sends a POST request to Fraud endpoint
     And user gets authorisation code
-    And user sends a POST request to Access Token endpoint fraud-cri-dev
+    And user sends a POST request to Access Token endpoint fraud-cri-shared-dev
     Then user requests Fraud CRI VC
     And VC should contain ci  and identityFraudScore 1
 
   @fraudCRI_API @pre-merge @dev
   Scenario: Fraud Check for user found on mortality record(STUB)
-    Given user ALBERT GILT has the user identity in the form of a signed JWT string for CRI Id fraud-cri-dev
+    Given user ALBERT GILT has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
     And user sends a POST request to session endpoint
     And user gets a session-id
     When user sends a POST request to Fraud endpoint
     And user gets authorisation code
-    And user sends a POST request to Access Token endpoint fraud-cri-dev
+    And user sends a POST request to Access Token endpoint fraud-cri-shared-dev
     Then user requests Fraud CRI VC
     And VC should contain ci T02 and identityFraudScore 0
 
   @fraudCRI_API @pre-merge @dev @LIME-415
   Scenario Outline: Fraud Check for users with potentially fraudulent CIs
-    Given user <givenName> <familyName> has the user identity in the form of a signed JWT string for CRI Id fraud-cri-dev
+    Given user <givenName> <familyName> has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
     And user sends a POST request to session endpoint
     And user gets a session-id
     When user sends a POST request to Fraud endpoint
     And user gets authorisation code
-    And user sends a POST request to Access Token endpoint fraud-cri-dev
+    And user sends a POST request to Access Token endpoint fraud-cri-shared-dev
     Then user requests Fraud CRI VC
     And VC should contain ci <ci> and identityFraudScore 2
     Examples:

--- a/acceptance-tests/src/test/resources/features/FraudCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/FraudCRIAPI.feature
@@ -1,14 +1,85 @@
 @fraud_CRI_API
 Feature: Fraud CRI API
 
-  @intialJWT_happy_path @pre-merge @dev
-  Scenario: Acquire initial JWT (STUB)
-    Given user has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
-    When user sends a POST request to session end point
-    Then user gets a session-id
+  @intialJWT_happy_path @fraudCRI_API @pre-merge @dev
+  Scenario: Acquire initial JWT and Fraud Check with PEP error response failure(STUB)
+    Given user ALBERT PEP_ERROR_RESPONSE has the user identity in the form of a signed JWT string for CRI Id fraud-cri-dev
+    And user sends a POST request to session endpoint
+    And user gets a session-id
+    When user sends a POST request to Fraud endpoint
+    And user gets authorisation code
+    And user sends a POST request to Access Token endpoint fraud-cri-dev
+    Then user requests Fraud CRI VC
+    And VC should contain ci  and identityFraudScore 1
 
-  @intialJWT_happy_path
-  Scenario: Acquire initial JWT (STUB)
-    Given user has the user identity in the form of a signed JWT string for CRI Id fraud-cri-build
-    When user sends a POST request to session end point
-    Then user gets a session-id
+  @fraudCRI_API @pre-merge @dev
+  Scenario: Acquire initial JWT and Fraud Check with PEP tech failure(STUB)
+    Given user ALBERT PEP_TECH_FAIL has the user identity in the form of a signed JWT string for CRI Id fraud-cri-dev
+    And user sends a POST request to session endpoint
+    And user gets a session-id
+    When user sends a POST request to Fraud endpoint
+    And user gets authorisation code
+    And user sends a POST request to Access Token endpoint fraud-cri-dev
+    Then user requests Fraud CRI VC
+    And VC should contain ci  and identityFraudScore 1
+
+  @fraudCRI_API @pre-merge @dev
+  Scenario: Fraud Check Succeeds and PEP Succeeds but is not PEP (HOLLINGDALU)
+    Given user ALBERT HOLLINGDALU has the user identity in the form of a signed JWT string for CRI Id fraud-cri-dev
+    And user sends a POST request to session endpoint
+    And user gets a session-id
+    When user sends a POST request to Fraud endpoint
+    And user gets authorisation code
+    And user sends a POST request to Access Token endpoint fraud-cri-dev
+    Then user requests Fraud CRI VC
+    And VC should contain ci  and identityFraudScore 2
+
+  @fraudCRI_API @pre-merge @dev
+  Scenario: Fraud Check and PEP check complete(STUB)
+#    VC for Fraud Succeeds and PEP Succeeds but is PEP (PEPS)
+    Given user ALBERT PEPS has the user identity in the form of a signed JWT string for CRI Id fraud-cri-dev
+    And user sends a POST request to session endpoint
+    And user gets a session-id
+    When user sends a POST request to Fraud endpoint
+    And user gets authorisation code
+    And user sends a POST request to Access Token endpoint fraud-cri-dev
+    Then user requests Fraud CRI VC
+    And VC should contain ci P01 and identityFraudScore 2
+
+  @fraudCRI_API @pre-merge @dev
+  Scenario: Fraud Happy path for user with decision score below 35(STUB)
+    Given user ALBERT NO_FILE_35 has the user identity in the form of a signed JWT string for CRI Id fraud-cri-dev
+    And user sends a POST request to session endpoint
+    And user gets a session-id
+    When user sends a POST request to Fraud endpoint
+    And user gets authorisation code
+    And user sends a POST request to Access Token endpoint fraud-cri-dev
+    Then user requests Fraud CRI VC
+    And VC should contain ci  and identityFraudScore 1
+
+  @fraudCRI_API @pre-merge @dev
+  Scenario: Fraud Check for user found on mortality record(STUB)
+    Given user ALBERT GILT has the user identity in the form of a signed JWT string for CRI Id fraud-cri-dev
+    And user sends a POST request to session endpoint
+    And user gets a session-id
+    When user sends a POST request to Fraud endpoint
+    And user gets authorisation code
+    And user sends a POST request to Access Token endpoint fraud-cri-dev
+    Then user requests Fraud CRI VC
+    And VC should contain ci T02 and identityFraudScore 0
+
+  @fraudCRI_API @pre-merge @dev @LIME-415
+  Scenario Outline: Fraud Check for users with potentially fraudulent CIs
+    Given user <givenName> <familyName> has the user identity in the form of a signed JWT string for CRI Id fraud-cri-dev
+    And user sends a POST request to session endpoint
+    And user gets a session-id
+    When user sends a POST request to Fraud endpoint
+    And user gets authorisation code
+    And user sends a POST request to Access Token endpoint fraud-cri-dev
+    Then user requests Fraud CRI VC
+    And VC should contain ci <ci> and identityFraudScore 2
+    Examples:
+      | givenName| familyName| ci  |
+      | Albert   | CI1       | A01 |
+      | Anthony  | CI2       | N01 |
+      | Albert   | CI5       | T05 |


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Adding API tests to cover a happy path journey’s for Fraud CRI

### What changed

This consists of the changes made as part of https://govukverify.atlassian.net/browse/LIME-415
API tests have been added to cover the following Fraud CRI journey

Fraud check + Peps complete (AC1)
Decision score below 35 (AC2)
User found of mortality register (AC3)
Users address possibly belongs to someone else / Home telephone supplied does not match database / Potential developed identity (AC5)
Have also updated the tags on the tests.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-XXXX](https://govukverify.atlassian.net/browse/KBV-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks