### PR TITLE
LIME-468 - Pinning gradle version to fix github actions

### DIFF
--- a/acceptance-tests/Dockerfile
+++ b/acceptance-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:jdk11
+FROM gradle:7.6.0-jdk11
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
 
 RUN apt-get update


### PR DESCRIPTION
### What changed

Pinned gradle version to fix github actions
