### PR TITLE
LIME-468 - Fixing aws pipeline testing stage

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/utilities/Driver.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/utilities/Driver.java
@@ -45,6 +45,7 @@ public class Driver {
                         chromeOptions.addArguments("--whitelisted-ips= ");
                         chromeOptions.addArguments("--disable-dev-shm-usage");
                         chromeOptions.addArguments("--remote-debugging-port=9222");
+                        chromeOptions.addArguments("--remote-allow-origins=*");
 
                         chromeOptions.addArguments("start-maximized");
                         chromeOptions.addArguments("disable-infobars");


### PR DESCRIPTION
### What changed

Added argument to chromeDriver to allow remote origins (eg localhost)

### Why did it change

To fix aws pipeline testing stage