### PR TITLE
fix: update configure-aws-credentials to v2

### DIFF
--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -36,7 +36,7 @@ jobs:
         uses: aws-actions/setup-sam@v1
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.DEV_CRI_V1_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: aws-actions/setup-sam@v1
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.BUILD_CRI_V1_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -40,7 +40,7 @@ jobs:
         uses: aws-actions/setup-sam@v1
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION }}


### PR DESCRIPTION
## Proposed changes

### What changed

The configure-aws-credentials action v1-node16 was failing due to a node12 reference which is no longer supported by GitHub. Version 2 has been released last week which resolves this issue. 

### Why did it change

To fix the failing workflows

### Issue tracking

- [OJ-1346-](https://govukverify.atlassian.net/browse/OJ-1346)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
