### PR TITLE
LIME-567 - Removed expiry on VC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		protobuf_version            : "3.19.4",
 		junit                       : "5.8.2",
 		mockito                     : "4.3.1",
-		cri_common_lib              : "1.4.1"
+		cri_common_lib              : "1.4.5"
 	]
 }
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -467,6 +467,7 @@ Resources:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/release-flags/vc-expiry-removed"
         - Statement:
             Effect: Allow
             Action:
@@ -573,6 +574,17 @@ Resources:
 # Parameters                                                       #
 #                                                                  #
 ####################################################################
+
+  ParameterReleaseFlagsVcExpiryRemoved:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !If
+        - IsDevEnvironment
+        - !Sub "/${AWS::StackName}/release-flags-vc-expiry-removed-not-used-in-dev"
+        - !Sub "/release-flags/vc-expiry-removed"
+      Value: "true"
+      Type: String
+      Description: Expiry date release toggle
 
   ParameterFraudItemTableName:
     Type: AWS::SSM::Parameter

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -121,6 +121,14 @@ Mappings:
       integration: "6"
       production: "6"
 
+  VcExpiryRemoved:
+    Environment:
+      dev: "true"
+      build: "true"
+      staging: "true"
+      integration: "true"
+      production: "false"
+
   # Permitted values: SECONDS,MINUTES,HOURS,DAYS,MONTHS,YEARS
   JwtTtlUnitMapping:
     Environment:
@@ -582,7 +590,7 @@ Resources:
         - IsDevEnvironment
         - !Sub "/${AWS::StackName}/release-flags-vc-expiry-removed-not-used-in-dev"
         - !Sub "/release-flags/vc-expiry-removed"
-      Value: "true"
+      Value: !FindInMap [ VcExpiryRemoved, Environment, !Ref Environment ]
       Type: String
       Description: Expiry date release toggle
 


### PR DESCRIPTION
### What changed
Enabled vc-expiry-removed feature toggle in Fraud CRI and disabled it in dev environment

### Why did it change
Release flag can't be enable on cri-dev stacks as they will be cross wired or blocked from deploying.
This is due to "/release-flags/vc-expiry-removed" path being forced by cri-lib as absolute rather than relative per stack.
On cri-dev, an unused variable is set instead with the feature toggle falling back to false by default.

