### PR TITLE
LIME-567: Enabling VC expiry removal in prod

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -127,7 +127,7 @@ Mappings:
       build: "true"
       staging: "true"
       integration: "true"
-      production: "false"
+      production: "true"
 
   # Permitted values: SECONDS,MINUTES,HOURS,DAYS,MONTHS,YEARS
   JwtTtlUnitMapping:


### PR DESCRIPTION
## Proposed changes

### What changed

Toggled the removal of expiry to true in production

### Why did it change

So that IPV core and spot have more control over when VCs expire

