### PR TITLE
LIME-633 Update acceptance tests to look for the full page title

### DIFF
--- a/acceptance-tests/run-local-tests.sh
+++ b/acceptance-tests/run-local-tests.sh
@@ -9,7 +9,7 @@ fi
 ##### Ask fundamental test questions
 read -p "What environment are you running against? [previous=$ENVIRONMENT] " ENVIRONMENT_NEW
 
-read -p "Are your running locally? [previous=$LOCAL] " LOCAL_NEW
+read -p "Are you using a local stub? [previous=$LOCAL] " LOCAL_NEW
 
 read -p "Are you including E2E tests? [previous=$E2E] " E2E_NEW
 

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
-import static gov.di_ipv_fraud.pages.Headers.CHECKING_YOUR_DETAILS;
+import static gov.di_ipv_fraud.pages.Headers.CHECK_PAGE_TITLE;
 import static gov.di_ipv_fraud.pages.Headers.IPV_CORE_STUB;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -209,7 +209,7 @@ public class FraudPageObject extends UniversalSteps {
     }
 
     public void navigateToResponse(String validOrInvalid) {
-        waitForTextToAppear(CHECKING_YOUR_DETAILS);
+        waitForTextToAppear(CHECK_PAGE_TITLE);
         checkYourDetailsContinue.click();
         assertURLContains("callback");
         if ("Invalid".equalsIgnoreCase(validOrInvalid)) {
@@ -220,7 +220,7 @@ public class FraudPageObject extends UniversalSteps {
     }
 
     public void whoWeCheckDetailsWith(String page) {
-        waitForTextToAppear(CHECKING_YOUR_DETAILS);
+        waitForTextToAppear(CHECK_PAGE_TITLE);
         whoWeCheckLink.click();
 
         if ("ThirdParty".equalsIgnoreCase(page)) {
@@ -273,10 +273,6 @@ public class FraudPageObject extends UniversalSteps {
         LOGGER.info("testStatusCode = " + testStatusCode);
         Assert.assertEquals(testErrorDescription, ActualErrorDescription);
         Assert.assertEquals(testStatusCode, ActualStatusCode);
-    }
-
-    public void goToPage(String page) {
-        waitForTextToAppear(page);
     }
 
     public void clickContinue() {
@@ -470,6 +466,10 @@ public class FraudPageObject extends UniversalSteps {
 
     public void expiryAbsentFromVC() throws JsonProcessingException {
         assertNbfIsRecentAndExpiryIsNull();
+    }
+
+    public void assertCurrentPageIsFraudCheckPage() {
+        waitForTextToAppear(CHECK_PAGE_TITLE);
     }
 
     private void assertNbfIsRecentAndExpiryIsNull() throws JsonProcessingException {

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/Headers.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/Headers.java
@@ -2,7 +2,10 @@ package gov.di_ipv_fraud.pages;
 
 public class Headers {
 
-    public static final String CHECKING_YOUR_DETAILS = "We need to check your details";
+    public static final String SERVICE_NAME = "Prove your identity";
+    public static final String GOV_UK = "GOV.UK";
+    public static final String CHECK_PAGE_TITLE =
+            String.format("We need to check your details – %s – %s", SERVICE_NAME, GOV_UK);
     public static final String IPV_CORE_STUB = "IPV Core Stub";
     public static final String CREDENTIAL_ISSUERS = "Visit Credential Issuers";
     public static final String PROBLEM_WITH_THE_SERVICE =

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/service/ConfigurationService.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/service/ConfigurationService.java
@@ -20,6 +20,7 @@ public class ConfigurationService {
     private final String privateApiGatewayId;
     private final String environment;
     private final String publicApiGatewayId;
+    private final boolean usingLocalStub;
 
     public ConfigurationService(String env) {
 
@@ -36,6 +37,7 @@ public class ConfigurationService {
         this.privateApiGatewayId = getParameter("API_GATEWAY_ID_PRIVATE");
         this.publicApiGatewayId = getParameter("API_GATEWAY_ID_PUBLIC");
         this.environment = env;
+        this.usingLocalStub = getParameter("LOCAL") != null && getParameter("LOCAL").equals("yes");
     }
 
     private String getParameter(String paramName) {
@@ -72,13 +74,14 @@ public class ConfigurationService {
         String coreStubPassword = this.getCoreStubPassword();
         String coreStubUrl = this.getCoreStubEndpoint();
 
-        if (null != coreStubUsername && null != coreStubPassword && withAuth) {
-            return "https://" + coreStubUsername + ":" + coreStubPassword + "@" + coreStubUrl;
+        if (usingLocalStub) {
+            return "http://" + coreStubUrl;
         } else {
-            if (!this.environment.equals("local") && !this.environment.equals("dev")) {
+            if (null != coreStubUsername && null != coreStubPassword && withAuth) {
+                return "https://" + coreStubUsername + ":" + coreStubPassword + "@" + coreStubUrl;
+            } else {
                 return "https://" + coreStubUrl;
             }
-            return "http://" + coreStubUrl;
         }
     }
 

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
@@ -65,9 +65,9 @@ public class FraudStepDefs extends FraudPageObject {
         jsonErrorResponse(testStatusCode);
     }
 
-    @And("^I navigate to the page (.*)$")
-    public void navigateToPage(String page) {
-        goToPage(page);
+    @And("^I confirm the current page is the fraud check page")
+    public void confirmCurrentPageIsFraudCheckPage() {
+        assertCurrentPageIsFraudCheckPage();
     }
 
     @When("^I check Continue button is enabled and click on the Continue button$")

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/ProveYourIdentityFullJourneyStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/ProveYourIdentityFullJourneyStepDefs.java
@@ -7,6 +7,7 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -50,6 +51,12 @@ public class ProveYourIdentityFullJourneyStepDefs extends ProveYourIdentityFullJ
     public void the_user_chooses_their_address_from_dropdown_and_click_Choose_address(
             String address) {
         selectAddressFromDropdown(address);
+    }
+
+    @When("the user enters the current year as the date they moved into their current address$")
+    public void
+            the_user_enters_the_current_year_as_the_date_they_moved_into_their_current_address() {
+        enterAddressExpiry(String.valueOf(LocalDate.now().getYear()));
     }
 
     @When("the user enters the date (.*) they moved into their current address$")

--- a/acceptance-tests/src/test/resources/features/FraudCRI.feature
+++ b/acceptance-tests/src/test/resources/features/FraudCRI.feature
@@ -45,7 +45,7 @@ Feature: Fraud CRI
     Given I navigate to the IPV Core Stub
     And I click the Fraud CRI for the testEnvironment
     And I search for user number 12 in the ThirdParty table
-    And I navigate to the page We need to check your details
+    And I confirm the current page is the fraud check page
     When I check Continue button is enabled and click on the Continue button
     Then I navigate to Verifiable Credentials page
     And I check for a Valid response from thirdParty

--- a/acceptance-tests/src/test/resources/features/ProveYourIdentityFullJourneyRoute.feature
+++ b/acceptance-tests/src/test/resources/features/ProveYourIdentityFullJourneyRoute.feature
@@ -9,13 +9,13 @@ Feature: Prove Your Identity Full Journey
     And I enter Passport Details
       | Passport number | Surname | First name |
       | 321654987       | DECERQUEIRA | KENNETH |
-    And I enter Date of birth as 23/08/1959
+    And I enter Date of birth as 08/07/1965
     And I enter Passport Expiry date as 01/01/2030 and Continue
     And I enter BA2 5AA in the Postcode field and find address
     And the user chooses their address 8 HADLEY ROAD, BATH, BA2 5AA from dropdown and click `Choose address`
     And the user enters the date 2014 they moved into their current address
     And the user clicks `I confirm my details are correct`
-    And I navigate to the page We need to check your details
+    And I confirm the current page is the fraud check page
     When I check Continue button is enabled and click on the Continue button
     And the user clicks `Answer security questions`
     And kenneth answers the first question correctly
@@ -34,18 +34,18 @@ Feature: Prove Your Identity Full Journey
     And I enter Passport Details
       | Passport number | Surname | First name |
       | 321654987       | DECERQUEIRA | KENNETH |
-    And I enter Date of birth as 23/08/1959
+    And I enter Date of birth as 08/07/1965
     And I enter Passport Expiry date as 01/01/2030 and Continue
     And I enter BA2 5AA in the Postcode field and find address
     And the user chooses their address 8 HADLEY ROAD, BATH, BA2 5AA from dropdown and click `Choose address`
-    And the user enters the date 2022 they moved into their current address
+    And the user enters the current year as the date they moved into their current address
     And they select `NO` for `Have you lived here for more than 3 months?` and click on `Continue`
     Then they should be on `What is your previous home address?`
     And I enter LS7 4JZ in the Postcode field and find address
     And the user chooses their address 16 NEWTON GARTH, LEEDS, LS7 4JZ from dropdown and click `Choose address`
     And the user clicks `I confirm my details are correct`
     And the user clicks `I confirm my details are correct`
-    And I navigate to the page We need to check your details
+    And I confirm the current page is the fraud check page
     When I check Continue button is enabled and click on the Continue button
     And the user clicks `Answer security questions`
     And kenneth answers the first question correctly


### PR DESCRIPTION
## Proposed changes

### What changed

This pr aligns tests with page title fixes in common-express.
Fixes some tests not finding the full page title, with service name and gov.uk appended.
Corrects test that are looking for and replicating a hardcoded page title
Service name and gov.uk are dynamically included in the page title check to avoid replicating the string in every test.

Correct issues causing end to end test to fail.

Aligned run local with dl-api, and passport-api-v1

### Why did it change

[fraud-front](https://github.com/alphagov/di-ipv-cri-fraud-front/pull/348 ) is being updated to use common-express to v1.0.0

Several tests where looking for hardcoded page title text and failing to match, the title is now generated separately and checked, rather than duplicated though the test as a string.

While testing the title page matching, the @proveYourIdentity_happyPath test was found to be broken by dob changes in the test user.

@proveYourIdentity_happyPath_multiple_addresses had hardcoded 2022 as the year - this has been updated to use the current year dynamically.

### Issue tracking

- https://github.com/alphagov/di-ipv-cri-fraud-front/pull/348
- [LIME-665](https://govukverify.atlassian.net/browse/LIME-665)
- [LIME-633](https://govukverify.atlassian.net/browse/LIME-633)
- [common-express v1.0.0](https://github.com/alphagov/di-ipv-cri-common-express/releases/tag/v1.0.0)


[LIME-665]: https://govukverify.atlassian.net/browse/LIME-665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ