### PR TITLE
LIME-565: Adding activity history score and associated checks to the VC

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -117,9 +117,9 @@ task cucumber() {
 				"${tags}",
 				'--glue',
 				'gov/di_ipv_fraud/step_definitions',
-				'src/test/resources' ,
+				'src/test/resources/features/' ,
 				'--plugin',
-				'html:build/test-results/cucmber.html',
+				'html:build/test-results/cucumber.html',
 				'--plugin',
 				'json:build/test-results/cucumber.json'
 			]

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/model/Check.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/model/Check.java
@@ -1,0 +1,83 @@
+package gov.di_ipv_fraud.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"txn", "checkMethod", "fraudCheck"})
+public class Check {
+
+    @JsonProperty("fraudCheck")
+    private String fraudCheck;
+
+    @JsonProperty("checkMethod")
+    private String checkMethod = "data";
+
+    @JsonProperty("activityFrom")
+    private String activityFrom;
+
+    // Txn is required for IPR Check
+    @JsonProperty("txn")
+    private String txn;
+
+    @JsonProperty("identityCheckPolicy")
+    private String identityCheckPolicy;
+
+    public Check(String fraudCheck) {
+        this.fraudCheck = fraudCheck;
+    }
+
+    public Check() {}
+
+    public String getFraudCheck() {
+        return fraudCheck;
+    }
+
+    public String getCheckMethod() {
+        return checkMethod;
+    }
+
+    public String getTxn() {
+        return txn;
+    }
+
+    public void setTxn(String txn) {
+        this.txn = txn;
+    }
+
+    public String getActivityFrom() {
+        return activityFrom;
+    }
+
+    public void setActivityFrom(String activityFrom) {
+        this.activityFrom = activityFrom;
+    }
+
+    public String getIdentityCheckPolicy() {
+        return identityCheckPolicy;
+    }
+
+    public void setIdentityCheckPolicy(String identityCheckPolicy) {
+        this.identityCheckPolicy = identityCheckPolicy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Check check = (Check) o;
+        return Objects.equals(fraudCheck, check.fraudCheck)
+                && Objects.equals(checkMethod, check.checkMethod)
+                && Objects.equals(activityFrom, check.activityFrom)
+                && Objects.equals(txn, check.txn)
+                && Objects.equals(identityCheckPolicy, check.identityCheckPolicy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fraudCheck, checkMethod, activityFrom, txn, identityCheckPolicy);
+    }
+}

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudAPIPage.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudAPIPage.java
@@ -235,7 +235,7 @@ public class FraudAPIPage {
     }
 
     public void activityHistoryScoreInVC(Integer activityHistoryScore)
-            throws URISyntaxException, IOException, InterruptedException, ParseException {
+            throws IOException, InterruptedException, ParseException {
         String fraudCRIVC = requestFraudCRIVC();
         LOGGER.info("fraudCRIVC = " + fraudCRIVC);
         JsonNode jsonNode = objectMapper.readTree((fraudCRIVC));
@@ -286,7 +286,7 @@ public class FraudAPIPage {
                 }
             }
         }
-        Assert.assertEquals(checkFound, evidenceChecks.size());
+        Assert.assertEquals(evidenceChecks.size(), checkFound);
     }
 
     private String getClaimsForUser(String baseUrl, String criId, int userDataRowNumber)

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudAPIStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudAPIStepDefs.java
@@ -20,11 +20,11 @@ public class FraudAPIStepDefs extends FraudAPIPage {
     }
 
     @Given(
-            "user (.*) (.*) has the user identity in the form of a signed JWT string for CRI Id (.*)$")
+            "user (.*) (.*) row number (.*) has the user identity in the form of a signed JWT string for CRI Id (.*)$")
     public void user_has_the_user_identity_in_the_form_of_a_signed_jwt_string(
-            String GivenName, String FamilyName, String criId)
+            String GivenName, String FamilyName, String rowNumber, String criId)
             throws URISyntaxException, IOException, InterruptedException {
-        userIdentityAsJwtStringForupdatedUser(GivenName, FamilyName, criId);
+        userIdentityAsJwtStringForupdatedUser(GivenName, FamilyName, criId, rowNumber);
     }
 
     @And("user sends a POST request to session endpoint")
@@ -65,10 +65,11 @@ public class FraudAPIStepDefs extends FraudAPIPage {
         ciAndIdentityFraudScoreInVC(ci, identityFraudScore);
     }
 
-    @And("user changes (.*) in session request to (.*)$")
-    public void userChangesFieldsInTheSessionRequest(String fieldName, String fieldValue)
+    @And("user changes (.*) in session request to (.*) for (.*)$")
+    public void userChangesFieldsInTheSessionRequest(
+            String fieldName, String fieldValue, String criId)
             throws IOException, InterruptedException, ParseException, URISyntaxException {
-        updateSessionRequestFieldWithValue(fieldName, fieldValue);
+        updateSessionRequestFieldWithValue(fieldName, fieldValue, criId);
     }
 
     @And("VC should contain activityHistory score of (.*)$")
@@ -82,5 +83,11 @@ public class FraudAPIStepDefs extends FraudAPIPage {
             throws IOException, InterruptedException, ParseException, URISyntaxException {
         List<String> checks = List.of(checksString.split(","));
         evidenceChecksInVC(checks);
+    }
+
+    @And("VC evidence activity`history check contains activity from (.*)$")
+    public void vc_should_contain_evidence_check_with_activity_from(String activityFrom)
+            throws IOException, InterruptedException, ParseException, URISyntaxException {
+        evidenceChecksInVC(List.of("activity_history_check"), activityFrom);
     }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudAPIStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudAPIStepDefs.java
@@ -9,6 +9,7 @@ import io.cucumber.java.en.When;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.text.ParseException;
+import java.util.List;
 
 public class FraudAPIStepDefs extends FraudAPIPage {
 
@@ -62,5 +63,24 @@ public class FraudAPIStepDefs extends FraudAPIPage {
     public void vc_should_contain_ci_and_identityFraudScore(String ci, Integer identityFraudScore)
             throws IOException, InterruptedException, ParseException, URISyntaxException {
         ciAndIdentityFraudScoreInVC(ci, identityFraudScore);
+    }
+
+    @And("user changes (.*) in session request to (.*)$")
+    public void userChangesFieldsInTheSessionRequest(String fieldName, String fieldValue)
+            throws IOException, InterruptedException, ParseException, URISyntaxException {
+        updateSessionRequestFieldWithValue(fieldName, fieldValue);
+    }
+
+    @And("VC should contain activityHistory score of (.*)$")
+    public void vc_should_contain_ci_and_identityFraudScore(Integer activityHistoryScore)
+            throws IOException, InterruptedException, ParseException, URISyntaxException {
+        activityHistoryScoreInVC(activityHistoryScore);
+    }
+
+    @And("VC evidence checks should contain (.*)$")
+    public void vc_should_contain_evidence_checks(String checksString)
+            throws IOException, InterruptedException, ParseException, URISyntaxException {
+        List<String> checks = List.of(checksString.split(","));
+        evidenceChecksInVC(checks);
     }
 }

--- a/acceptance-tests/src/test/resources/features/FraudCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/FraudCRIAPI.feature
@@ -68,6 +68,24 @@ Feature: Fraud CRI API
     Then user requests Fraud CRI VC
     And VC should contain ci T02 and identityFraudScore 0
 
+  @fraudCRI_API @pre-merge1 @dev
+  Scenario Outline: Fraud Check for user with various activity history records(STUB)
+    Given user ALBERT GILT has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
+    Given user changes <field> in session request to <fieldValue>
+    And user sends a POST request to session endpoint
+    And user gets a session-id
+    When user sends a POST request to Fraud endpoint
+    And user gets authorisation code
+    And user sends a POST request to Access Token endpoint fraud-cri-shared-dev
+    Then user requests Fraud CRI VC
+    And VC should contain ci  and identityFraudScore <identityFraudScore>
+    And VC should contain activityHistory score of <activityHistoryScore>
+    And VC evidence checks should contain <checks>
+    Examples:
+      | field    | fieldValue | identityFraudScore | activityHistoryScore | checks
+      | lastName | GILT       | 2                  | 0                    | mortality_check, identity_theft_check, synthetic_identity_check, impersonation_risk_check |
+      | lastName | AHS        | 2                  | 1                    | mortality_check, identity_theft_check, synthetic_identity_check, impersonation_risk_check, activity_history_check |
+
   @fraudCRI_API @pre-merge @dev @LIME-415
   Scenario Outline: Fraud Check for users with potentially fraudulent CIs
     Given user <givenName> <familyName> has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev

--- a/acceptance-tests/src/test/resources/features/FraudCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/FraudCRIAPI.feature
@@ -3,7 +3,7 @@ Feature: Fraud CRI API
 
   @intialJWT_happy_path @fraudCRI_API @pre-merge @dev
   Scenario: Acquire initial JWT and Fraud Check with PEP error response failure(STUB)
-    Given user ALBERT PEP_ERROR_RESPONSE has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
+    Given user ALBERT PEP_ERROR_RESPONSE row number 6 has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
     And user sends a POST request to session endpoint
     And user gets a session-id
     When user sends a POST request to Fraud endpoint
@@ -14,7 +14,7 @@ Feature: Fraud CRI API
 
   @fraudCRI_API @pre-merge @dev
   Scenario: Acquire initial JWT and Fraud Check with PEP tech failure(STUB)
-    Given user ALBERT PEP_TECH_FAIL has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
+    Given user ALBERT PEP_TECH_FAIL row number 6 has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
     And user sends a POST request to session endpoint
     And user gets a session-id
     When user sends a POST request to Fraud endpoint
@@ -25,7 +25,7 @@ Feature: Fraud CRI API
 
   @fraudCRI_API @pre-merge @dev
   Scenario: Fraud Check Succeeds and PEP Succeeds but is not PEP (HOLLINGDALU)
-    Given user ALBERT HOLLINGDALU has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
+    Given user ALBERT HOLLINGDALU row number 6 has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
     And user sends a POST request to session endpoint
     And user gets a session-id
     When user sends a POST request to Fraud endpoint
@@ -37,7 +37,7 @@ Feature: Fraud CRI API
   @fraudCRI_API @pre-merge @dev
   Scenario: Fraud Check and PEP check complete(STUB)
 #    VC for Fraud Succeeds and PEP Succeeds but is PEP (PEPS)
-    Given user ALBERT PEPS has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
+    Given user ALBERT PEPS row number 6 has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
     And user sends a POST request to session endpoint
     And user gets a session-id
     When user sends a POST request to Fraud endpoint
@@ -48,7 +48,7 @@ Feature: Fraud CRI API
 
   @fraudCRI_API @pre-merge @dev
   Scenario: Fraud Happy path for user with decision score below 35(STUB)
-    Given user ALBERT NO_FILE_35 has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
+    Given user ALBERT NO_FILE_35 row number 6 has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
     And user sends a POST request to session endpoint
     And user gets a session-id
     When user sends a POST request to Fraud endpoint
@@ -59,7 +59,7 @@ Feature: Fraud CRI API
 
   @fraudCRI_API @pre-merge @dev
   Scenario: Fraud Check for user found on mortality record(STUB)
-    Given user ALBERT GILT has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
+    Given user ALBERT GILT row number 6 has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
     And user sends a POST request to session endpoint
     And user gets a session-id
     When user sends a POST request to Fraud endpoint
@@ -68,10 +68,10 @@ Feature: Fraud CRI API
     Then user requests Fraud CRI VC
     And VC should contain ci T02 and identityFraudScore 0
 
-  @fraudCRI_API @pre-merge1 @dev
+  @fraudCRI_API @pre-merge @dev
   Scenario Outline: Fraud Check for user with various activity history records(STUB)
-    Given user ALBERT GILT has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
-    Given user changes <field> in session request to <fieldValue>
+    Given user LINDA DUFF row number 6 has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
+    Given user changes <field> in session request to <fieldValue> for fraud-cri-shared-dev
     And user sends a POST request to session endpoint
     And user gets a session-id
     When user sends a POST request to Fraud endpoint
@@ -82,13 +82,31 @@ Feature: Fraud CRI API
     And VC should contain activityHistory score of <activityHistoryScore>
     And VC evidence checks should contain <checks>
     Examples:
-      | field    | fieldValue | identityFraudScore | activityHistoryScore | checks
-      | lastName | GILT       | 2                  | 0                    | mortality_check, identity_theft_check, synthetic_identity_check, impersonation_risk_check |
-      | lastName | AHS        | 2                  | 1                    | mortality_check, identity_theft_check, synthetic_identity_check, impersonation_risk_check, activity_history_check |
+      | field    | fieldValue | identityFraudScore | activityHistoryScore | checks |
+      | lastName | DUFF       | 2                  | 0                    | mortality_check,identity_theft_check,synthetic_identity_check,impersonation_risk_check |
+      | lastName | AHS        | 2                  | 1                    | mortality_check,identity_theft_check,synthetic_identity_check,impersonation_risk_check,activity_history_check |
+
+  @fraudCRI_API @staging
+  Scenario Outline: Fraud Check for user with various activity history records(STUB)
+    Given user PAUL BUTTIVANT row number 5 has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
+    Given user changes <field> in session request to <fieldValue> for fraud-cri-shared-dev
+    And user sends a POST request to session endpoint
+    And user gets a session-id
+    When user sends a POST request to Fraud endpoint
+    And user gets authorisation code
+    And user sends a POST request to Access Token endpoint fraud-cri-shared-dev
+    Then user requests Fraud CRI VC
+    And VC should contain ci  and identityFraudScore <identityFraudScore>
+    And VC should contain activityHistory score of <activityHistoryScore>
+    And VC evidence checks should contain <checks>
+    And VC evidence activity`history check contains activity from <activityFrom>
+    Examples:
+      | field    | fieldValue | identityFraudScore | activityHistoryScore | activityFrom | checks |
+      | lastName | BUTTIVANT  | 1                  | 1                    | 2013-12-01   | mortality_check,identity_theft_check,synthetic_identity_check,impersonation_risk_check,activity_history_check |
 
   @fraudCRI_API @pre-merge @dev @LIME-415
   Scenario Outline: Fraud Check for users with potentially fraudulent CIs
-    Given user <givenName> <familyName> has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
+    Given user <givenName> <familyName> row number 6 has the user identity in the form of a signed JWT string for CRI Id fraud-cri-shared-dev
     And user sends a POST request to session endpoint
     And user gets a session-id
     When user sends a POST request to Fraud endpoint

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -154,6 +154,13 @@ Mappings:
       integration: "true"
       production: "true"
 
+  ActivityHistoryScoreInVcMapping:
+    Environment:
+      dev: "true"
+      build: "true"
+      staging: "true"
+      integration: "false"
+      production: "false"
 
 
 Resources:
@@ -471,6 +478,7 @@ Resources:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaxJwtTtl"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/JwtTtlUnit"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/contraindicationMappings"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/activityHistoryEnabled"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiableCredentialKmsSigningKeyId"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
@@ -625,6 +633,14 @@ Resources:
       Type: String
       Value: !FindInMap [ FraudCriPepEnabledMapping, Environment, !Ref 'Environment' ]
       Description: The fraud PEP enabled feature toggle
+
+  ParameterReleaseFlagsVcActivityHistory:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/activityHistoryEnabled"
+      Type: String
+      Value: !FindInMap [ ActivityHistoryScoreInVcMapping, Environment, !Ref 'Environment' ]
+      Description: Feature toggle to enable or disable activity history within the VC
 
   JwtTtlUnitParameter:
     Type: AWS::SSM::Parameter

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/IdentityVerificationResult.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/IdentityVerificationResult.java
@@ -10,6 +10,7 @@ public class IdentityVerificationResult {
     private List<String> contraIndicators = new ArrayList<>();
     private int identityCheckScore;
     private int activityHistoryScore;
+    private String activityFrom;
     private String transactionId;
     private String pepTransactionId;
     private String decisionScore;
@@ -113,5 +114,13 @@ public class IdentityVerificationResult {
 
     public void setActivityHistoryScore(int activityHistoryScore) {
         this.activityHistoryScore = activityHistoryScore;
+    }
+
+    public String getActivityFrom() {
+        return activityFrom;
+    }
+
+    public void setActivityFrom(String activityFrom) {
+        this.activityFrom = activityFrom;
     }
 }

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
@@ -162,6 +162,8 @@ public class FraudHandler
             fraudResultItem.setCheckDetails(result.getChecksSucceeded());
             fraudResultItem.setFailedCheckDetails(result.getChecksFailed());
 
+            fraudResultItem.setActivityFrom(result.getActivityFrom());
+
             LOGGER.info("Saving fraud results...");
             dataStore.create(fraudResultItem);
             LOGGER.info("Fraud results saved.");

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
@@ -17,6 +17,8 @@ import uk.gov.di.ipv.cri.fraud.api.domain.ValidationResult;
 import uk.gov.di.ipv.cri.fraud.api.domain.audit.TPREFraudAuditExtension;
 import uk.gov.di.ipv.cri.fraud.api.gateway.ThirdPartyFraudGateway;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -121,7 +123,9 @@ public class IdentityVerificationService {
         identityVerificationResult.setIdentityCheckScore(identityCheckScore);
 
         int activityHistoryScore = fraudIdentityVerificationResult.getActivityHistoryScore();
+        String activityFrom = fraudIdentityVerificationResult.getActivityFrom();
         identityVerificationResult.setActivityHistoryScore(activityHistoryScore);
+        identityVerificationResult.setActivityFrom(activityFrom);
 
         identityVerificationResult.setError(
                 fraudIdentityVerificationResult.getError() != null
@@ -272,6 +276,9 @@ public class IdentityVerificationService {
         LOGGER.info("IdentityCheckScore after Fraud {}", fraudIdentityCheckScore);
         identityVerificationResult.setIdentityCheckScore(fraudIdentityCheckScore);
         identityVerificationResult.setActivityHistoryScore(activityHistoryScore);
+
+        String activityFrom = getActivityFrom(fraudCheckResult);
+        identityVerificationResult.setActivityFrom(activityFrom);
 
         String stringFraudContraindications = String.join(", ", fraudContraindications);
         LOGGER.info(
@@ -446,5 +453,15 @@ public class IdentityVerificationService {
         combinedThirdPartyFraudCodes.addAll(
                 pepIdentityVerificationResult.getThirdPartyFraudCodes());
         return combinedThirdPartyFraudCodes;
+    }
+
+    private String getActivityFrom(FraudCheckResult fraudCheckResult) {
+        LocalDate dateNow = LocalDate.now();
+        LocalDate oldestRecordDate = dateNow.minusMonths(0);
+        if (null != fraudCheckResult.getOldestRecordDateInMonths()) {
+            oldestRecordDate = dateNow.minusMonths(fraudCheckResult.getOldestRecordDateInMonths());
+        }
+        String activityFrom = oldestRecordDate.withDayOfMonth(1).format(DateTimeFormatter.ISO_DATE);
+        return activityFrom;
     }
 }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
@@ -24,12 +24,15 @@ import uk.gov.di.ipv.cri.fraud.api.gateway.ThirdPartyFraudGateway;
 import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -104,6 +107,8 @@ class IdentityVerificationServiceTest {
         when(mockContraindicationMapper.mapThirdPartyFraudCodes(thirdPartyFraudCodes))
                 .thenReturn(mappedFraudCodes);
 
+        when(mockActivityHistoryScoreCalculator.calculateActivityHistoryScore(null)).thenReturn(0);
+
         IdentityVerificationResult result =
                 this.identityVerificationService.verifyIdentity(
                         testPersonIdentity, sessionItem, requestHeaders);
@@ -116,6 +121,11 @@ class IdentityVerificationServiceTest {
         assertNotNull(result);
         assertTrue(result.isSuccess());
         assertEquals(mappedFraudCodes[0], result.getContraIndicators().get(0));
+        assertEquals(result.getActivityHistoryScore(), 0);
+        assertEquals(
+                result.getActivityFrom(),
+                LocalDate.now().withDayOfMonth(1).format(DateTimeFormatter.ISO_DATE));
+
         verify(personIdentityValidator).validate(testPersonIdentity);
         verify(mockThirdPartyGateway).performFraudCheck(testPersonIdentity, false);
         verify(mockThirdPartyGateway, never()).performFraudCheck(testPersonIdentity, true);
@@ -130,6 +140,7 @@ class IdentityVerificationServiceTest {
         FraudCheckResult testFraudCheckResult = new FraudCheckResult();
         testFraudCheckResult.setExecutedSuccessfully(true);
         testFraudCheckResult.setDecisionScore("60");
+        testFraudCheckResult.setOldestRecordDateInMonths(366);
 
         FraudCheckResult testPEPCheckResult = new FraudCheckResult();
         testPEPCheckResult.setExecutedSuccessfully(true);
@@ -156,6 +167,8 @@ class IdentityVerificationServiceTest {
         when(mockContraindicationMapper.mapThirdPartyFraudCodes(thirdPartyPEPCodes))
                 .thenReturn(mappedPEPCodes);
 
+        when(mockActivityHistoryScoreCalculator.calculateActivityHistoryScore(366)).thenReturn(1);
+
         IdentityVerificationResult result =
                 this.identityVerificationService.verifyIdentity(
                         testPersonIdentity, sessionItem, requestHeaders);
@@ -171,6 +184,8 @@ class IdentityVerificationServiceTest {
         assertTrue(result.isSuccess());
         assertEquals(mappedFraudCodes[0], result.getContraIndicators().get(0));
         assertEquals(mappedPEPCodes[0], result.getContraIndicators().get(1));
+        assertEquals(result.getActivityHistoryScore(), 1);
+        assertEquals(result.getActivityFrom(), "1992-12-01");
 
         verify(personIdentityValidator).validate(testPersonIdentity);
         verify(mockThirdPartyGateway).performFraudCheck(testPersonIdentity, false);
@@ -200,6 +215,8 @@ class IdentityVerificationServiceTest {
         inOrder.verify(mockEventProbe, never()).counterMetric(IDENTITY_CHECK_SCORE_PREFIX + 2);
 
         assertNotNull(result);
+        assertEquals(result.getActivityHistoryScore(), 0);
+        assertNull(result.getActivityFrom());
         assertTrue(result.getContraIndicators().isEmpty());
         assertFalse(result.isSuccess());
         assertEquals(validationErrors.get(0), result.getValidationErrors().get(0));
@@ -432,6 +449,7 @@ class IdentityVerificationServiceTest {
         String[] thirdPartyFraudCodes = new String[] {"sample-f-code"};
         String[] mappedFraudCodes = new String[] {"mapped-f-code"};
         testFraudCheckResult.setThirdPartyFraudCodes(thirdPartyFraudCodes);
+        testFraudCheckResult.setOldestRecordDateInMonths(366);
 
         FraudCheckResult testPEPCheckResult = new FraudCheckResult();
         testPEPCheckResult.setExecutedSuccessfully(
@@ -449,6 +467,8 @@ class IdentityVerificationServiceTest {
                 .thenReturn(testFraudCheckResult);
         when(mockContraindicationMapper.mapThirdPartyFraudCodes(thirdPartyFraudCodes))
                 .thenReturn(mappedFraudCodes);
+
+        when(mockActivityHistoryScoreCalculator.calculateActivityHistoryScore(366)).thenReturn(1);
 
         // Pep is checked to be enabled
         when(mockConfigurationService.getPepEnabled()).thenReturn(Boolean.TRUE);
@@ -475,6 +495,8 @@ class IdentityVerificationServiceTest {
 
         assertNotNull(result);
         assertTrue(result.isSuccess());
+        assertEquals(result.getActivityHistoryScore(), 1);
+        assertEquals(result.getActivityFrom(), "1992-12-01");
 
         // Fraud ucodes
         assertEquals(mappedFraudCodes[0], result.getContraIndicators().get(0));

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
@@ -121,10 +121,10 @@ class IdentityVerificationServiceTest {
         assertNotNull(result);
         assertTrue(result.isSuccess());
         assertEquals(mappedFraudCodes[0], result.getContraIndicators().get(0));
-        assertEquals(result.getActivityHistoryScore(), 0);
+        assertEquals(0, result.getActivityHistoryScore());
         assertEquals(
-                result.getActivityFrom(),
-                LocalDate.now().withDayOfMonth(1).format(DateTimeFormatter.ISO_DATE));
+                LocalDate.now().withDayOfMonth(1).format(DateTimeFormatter.ISO_DATE),
+                result.getActivityFrom());
 
         verify(personIdentityValidator).validate(testPersonIdentity);
         verify(mockThirdPartyGateway).performFraudCheck(testPersonIdentity, false);
@@ -184,8 +184,8 @@ class IdentityVerificationServiceTest {
         assertTrue(result.isSuccess());
         assertEquals(mappedFraudCodes[0], result.getContraIndicators().get(0));
         assertEquals(mappedPEPCodes[0], result.getContraIndicators().get(1));
-        assertEquals(result.getActivityHistoryScore(), 1);
-        assertEquals(result.getActivityFrom(), "1992-12-01");
+        assertEquals(1, result.getActivityHistoryScore());
+        assertEquals("1992-12-01", result.getActivityFrom());
 
         verify(personIdentityValidator).validate(testPersonIdentity);
         verify(mockThirdPartyGateway).performFraudCheck(testPersonIdentity, false);
@@ -215,7 +215,7 @@ class IdentityVerificationServiceTest {
         inOrder.verify(mockEventProbe, never()).counterMetric(IDENTITY_CHECK_SCORE_PREFIX + 2);
 
         assertNotNull(result);
-        assertEquals(result.getActivityHistoryScore(), 0);
+        assertEquals(0, result.getActivityHistoryScore());
         assertNull(result.getActivityFrom());
         assertTrue(result.getContraIndicators().isEmpty());
         assertFalse(result.isSuccess());
@@ -495,8 +495,8 @@ class IdentityVerificationServiceTest {
 
         assertNotNull(result);
         assertTrue(result.isSuccess());
-        assertEquals(result.getActivityHistoryScore(), 1);
-        assertEquals(result.getActivityFrom(), "1992-12-01");
+        assertEquals(1, result.getActivityHistoryScore());
+        assertEquals("1992-12-01", result.getActivityFrom());
 
         // Fraud ucodes
         assertEquals(mappedFraudCodes[0], result.getContraIndicators().get(0));

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/Evidence.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/Evidence.java
@@ -19,6 +19,9 @@ public class Evidence {
     @JsonProperty("identityFraudScore")
     private Integer identityFraudScore;
 
+    @JsonProperty("activityHistoryScore")
+    private Integer activityHistoryScore;
+
     @JsonProperty("ci")
     private List<String> ci;
 
@@ -85,5 +88,13 @@ public class Evidence {
 
     public void setFailedCheckDetails(List<Check> failedCheckDetails) {
         this.failedCheckDetails = failedCheckDetails;
+    }
+
+    public Integer getActivityHistoryScore() {
+        return activityHistoryScore;
+    }
+
+    public void setActivityHistoryScore(Integer activityHistoryScore) {
+        this.activityHistoryScore = activityHistoryScore;
     }
 }

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/checkdetails/Check.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/checkdetails/Check.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.util.Objects;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"txn", "checkMethod", "fraudCheck"})
 public class Check {
@@ -14,13 +16,21 @@ public class Check {
     @JsonProperty("checkMethod")
     private String checkMethod = "data";
 
+    @JsonProperty("activityFrom")
+    private String activityFrom;
+
     // Txn is required for IPR Check
     @JsonProperty("txn")
     private String txn;
 
+    @JsonProperty("identityCheckPolicy")
+    private String identityCheckPolicy;
+
     public Check(String fraudCheck) {
         this.fraudCheck = fraudCheck;
     }
+
+    public Check() {}
 
     public String getFraudCheck() {
         return fraudCheck;
@@ -36,5 +46,38 @@ public class Check {
 
     public void setTxn(String txn) {
         this.txn = txn;
+    }
+
+    public String getActivityFrom() {
+        return activityFrom;
+    }
+
+    public void setActivityFrom(String activityFrom) {
+        this.activityFrom = activityFrom;
+    }
+
+    public String getIdentityCheckPolicy() {
+        return identityCheckPolicy;
+    }
+
+    public void setIdentityCheckPolicy(String identityCheckPolicy) {
+        this.identityCheckPolicy = identityCheckPolicy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        Check check = (Check) o;
+        return Objects.equals(fraudCheck, check.fraudCheck)
+                && Objects.equals(checkMethod, check.checkMethod)
+                && Objects.equals(activityFrom, check.activityFrom)
+                && Objects.equals(txn, check.txn)
+                && Objects.equals(identityCheckPolicy, check.identityCheckPolicy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fraudCheck, checkMethod, activityFrom, txn, identityCheckPolicy);
     }
 }

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationService.java
@@ -14,6 +14,7 @@ public class ConfigurationService {
 
     private final String fraudResultTableName;
     private final String contraindicationMappings;
+    private final boolean activityHistoryEnabled;
     private final String parameterPrefix;
 
     public ConfigurationService(
@@ -28,6 +29,8 @@ public class ConfigurationService {
         this.contraindicationMappings =
                 paramProvider.get(getParameterName("contraindicationMappings"));
         this.fraudResultTableName = paramProvider.get(getParameterName("FraudTableName"));
+        this.activityHistoryEnabled =
+                Boolean.parseBoolean(paramProvider.get(getParameterName("activityHistoryEnabled")));
     }
 
     public String getFraudResultTableName() {
@@ -36,6 +39,10 @@ public class ConfigurationService {
 
     public String getContraindicationMappings() {
         return contraindicationMappings;
+    }
+
+    public boolean isActivityHistoryEnabled() {
+        return activityHistoryEnabled;
     }
 
     public String getParameterName(String parameterName) {

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/EvidenceHelper.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/EvidenceHelper.java
@@ -25,6 +25,7 @@ public class EvidenceHelper {
         evidence.setIdentityFraudScore(fraudResultItem.getIdentityFraudScore());
         evidence.setCi(fraudResultItem.getContraIndicators());
         evidence.setDecisionScore(fraudResultItem.getDecisionScore());
+        evidence.setActivityHistoryScore(fraudResultItem.getActivityHistoryScore());
 
         List<String> stringCheckDetails = fraudResultItem.getCheckDetails();
         if (stringCheckDetails != null && !stringCheckDetails.isEmpty()) {
@@ -51,10 +52,18 @@ public class EvidenceHelper {
             Check check = new Check(checkName.toLowerCase());
 
             // IPR check has the transaction recorded in the check result
-            if (checkName.equals(IMPERSONATION_RISK_CHECK.toString())) {
+            if (checkName.equalsIgnoreCase(IMPERSONATION_RISK_CHECK.toString())) {
                 check.setTxn(resultItem.getPepTransactionId());
             }
 
+            checkList.add(check);
+        }
+
+        if (resultItem.getActivityHistoryScore() != null
+                && resultItem.getActivityHistoryScore() != 0) {
+            Check check = new Check();
+            check.setActivityFrom(resultItem.getActivityFrom());
+            check.setIdentityCheckPolicy("none");
             checkList.add(check);
         }
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/EvidenceHelper.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/EvidenceHelper.java
@@ -16,7 +16,8 @@ public class EvidenceHelper {
         throw new IllegalStateException("Instantiation is not valid for this class.");
     }
 
-    public static Evidence fraudCheckResultItemToEvidence(FraudResultItem fraudResultItem) {
+    public static Evidence fraudCheckResultItemToEvidence(
+            FraudResultItem fraudResultItem, boolean activityHistoryEnabled) {
 
         Evidence evidence = new Evidence();
 
@@ -25,24 +26,29 @@ public class EvidenceHelper {
         evidence.setIdentityFraudScore(fraudResultItem.getIdentityFraudScore());
         evidence.setCi(fraudResultItem.getContraIndicators());
         evidence.setDecisionScore(fraudResultItem.getDecisionScore());
-        evidence.setActivityHistoryScore(fraudResultItem.getActivityHistoryScore());
+
+        if (activityHistoryEnabled) {
+            evidence.setActivityHistoryScore(fraudResultItem.getActivityHistoryScore());
+        }
 
         List<String> stringCheckDetails = fraudResultItem.getCheckDetails();
         if (stringCheckDetails != null && !stringCheckDetails.isEmpty()) {
-            evidence.setCheckDetails(createCheckList(stringCheckDetails, fraudResultItem));
+            evidence.setCheckDetails(
+                    createCheckList(stringCheckDetails, fraudResultItem, activityHistoryEnabled));
         }
 
         List<String> stringFailedCheckDetails = fraudResultItem.getFailedCheckDetails();
         if (stringFailedCheckDetails != null && !stringFailedCheckDetails.isEmpty()) {
             evidence.setFailedCheckDetails(
-                    createCheckList(stringFailedCheckDetails, fraudResultItem));
+                    createCheckList(
+                            stringFailedCheckDetails, fraudResultItem, activityHistoryEnabled));
         }
 
         return evidence;
     }
 
     private static List<Check> createCheckList(
-            List<String> stringChecks, FraudResultItem resultItem) {
+            List<String> stringChecks, FraudResultItem resultItem, boolean activityHistoryEnabled) {
 
         List<Check> checkList = new ArrayList<>();
 
@@ -59,12 +65,14 @@ public class EvidenceHelper {
             checkList.add(check);
         }
 
-        if (resultItem.getActivityHistoryScore() != null
-                && resultItem.getActivityHistoryScore() != 0) {
-            Check check = new Check();
-            check.setActivityFrom(resultItem.getActivityFrom());
-            check.setIdentityCheckPolicy("none");
-            checkList.add(check);
+        if (activityHistoryEnabled) {
+            if (resultItem.getActivityHistoryScore() != null
+                    && resultItem.getActivityHistoryScore() != 0) {
+                Check check = new Check();
+                check.setActivityFrom(resultItem.getActivityFrom());
+                check.setIdentityCheckPolicy("none");
+                checkList.add(check);
+            }
         }
 
         return checkList;

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/IssueCredentialFraudAuditExtensionUtil.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/IssueCredentialFraudAuditExtensionUtil.java
@@ -14,13 +14,17 @@ public class IssueCredentialFraudAuditExtensionUtil {
     }
 
     public static VCISSFraudAuditExtension generateVCISSFraudAuditExtension(
-            String vcIssuer, List<FraudResultItem> fraudResultItems) {
+            String vcIssuer,
+            List<FraudResultItem> fraudResultItems,
+            boolean activityHistoryEnabled) {
 
         List<Evidence> evidenceList = new ArrayList<>();
 
         for (FraudResultItem fraudResultItem : fraudResultItems) {
 
-            Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem);
+            Evidence evidence =
+                    EvidenceHelper.fraudCheckResultItemToEvidence(
+                            fraudResultItem, activityHistoryEnabled);
 
             evidenceList.add(evidence);
         }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/IssueCredentialHandlerTest.java
@@ -33,6 +33,7 @@ import uk.gov.di.ipv.cri.common.library.service.PersonIdentityService;
 import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.fraud.api.domain.audit.VCISSFraudAuditExtension;
+import uk.gov.di.ipv.cri.fraud.api.service.ConfigurationService;
 import uk.gov.di.ipv.cri.fraud.api.service.FraudRetrievalService;
 import uk.gov.di.ipv.cri.fraud.api.service.VerifiableCredentialService;
 import uk.gov.di.ipv.cri.fraud.api.util.FraudPersonIdentityDetailedMapper;
@@ -60,6 +61,7 @@ class IssueCredentialHandlerTest {
     @Mock private FraudRetrievalService mockFraudRetrievalService;
     @Mock private EventProbe mockEventProbe;
     @Mock private AuditService mockAuditService;
+    @Mock private ConfigurationService mockConfigurationService;
     @InjectMocks private IssueCredentialHandler handler;
 
     @Test
@@ -87,6 +89,7 @@ class IssueCredentialHandlerTest {
         when(mockVerifiableCredentialService.generateSignedVerifiableCredentialJwt(
                         sessionItem.getSubject(), fraudResultItem, personIdentityDetailed))
                 .thenReturn(mock(SignedJWT.class));
+        when(mockConfigurationService.isActivityHistoryEnabled()).thenReturn(true);
         doNothing()
                 .when(mockAuditService)
                 .sendAuditEvent(

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/VerifiableCredentialServiceTest.java
@@ -49,7 +49,8 @@ class VerifiableCredentialServiceTest implements TestFixtures {
     private final String UNIT_TEST_VC_ISSUER = "UNIT_TEST_VC_ISSUER";
     private final String UNIT_TEST_SUBJECT = "UNIT_TEST_SUBJECT";
 
-    @Mock private ConfigurationService mockConfigurationService;
+    @Mock private ConfigurationService mockCommonConfigurationService;
+    @Mock private uk.gov.di.ipv.cri.fraud.api.service.ConfigurationService mockConfigurationService;
 
     private ObjectMapper objectMapper;
 
@@ -62,16 +63,17 @@ class VerifiableCredentialServiceTest implements TestFixtures {
         objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
 
-        when(mockConfigurationService.getParameterValue("JwtTtlUnit")).thenReturn("SECONDS");
+        when(mockCommonConfigurationService.getParameterValue("JwtTtlUnit")).thenReturn("SECONDS");
         VerifiableCredentialClaimsSetBuilder verifiableCredentialClaimsSetBuilder =
                 new VerifiableCredentialClaimsSetBuilder(
-                        mockConfigurationService, Clock.systemUTC());
+                        mockCommonConfigurationService, Clock.systemUTC());
         verifiableCredentialService =
                 new VerifiableCredentialService(
                         signedJwtFactory,
-                        mockConfigurationService,
+                        mockCommonConfigurationService,
                         objectMapper,
-                        verifiableCredentialClaimsSetBuilder);
+                        verifiableCredentialClaimsSetBuilder,
+                        mockConfigurationService);
     }
 
     @ParameterizedTest
@@ -117,9 +119,9 @@ class VerifiableCredentialServiceTest implements TestFixtures {
                 FraudPersonIdentityDetailedMapper.generatePersonIdentityDetailed(
                         TestDataCreator.createTestPersonIdentityMultipleAddresses(addressCount));
 
-        when(mockConfigurationService.getVerifiableCredentialIssuer())
+        when(mockCommonConfigurationService.getVerifiableCredentialIssuer())
                 .thenReturn(UNIT_TEST_VC_ISSUER);
-        when(mockConfigurationService.getMaxJwtTtl()).thenReturn(maxExpiryTime);
+        when(mockCommonConfigurationService.getMaxJwtTtl()).thenReturn(maxExpiryTime);
 
         SignedJWT signedJWT =
                 verifiableCredentialService.generateSignedVerifiableCredentialJwt(

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/EvidenceHelperTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/EvidenceHelperTest.java
@@ -31,12 +31,12 @@ class EvidenceHelperTest {
 
         Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem, true);
 
-        assertEquals(evidence.getType(), IDENTITY_CHECK.toString());
-        assertEquals(evidence.getTxn(), fraudResultItem.getTransactionId());
-        assertEquals(evidence.getIdentityFraudScore(), fraudResultItem.getIdentityFraudScore());
-        assertEquals(evidence.getCi(), fraudResultItem.getContraIndicators());
-        assertEquals(evidence.getDecisionScore(), fraudResultItem.getDecisionScore());
-        assertEquals(evidence.getActivityHistoryScore(), fraudResultItem.getActivityHistoryScore());
+        assertEquals(IDENTITY_CHECK.toString(), evidence.getType());
+        assertEquals(fraudResultItem.getTransactionId(), evidence.getTxn());
+        assertEquals(fraudResultItem.getIdentityFraudScore(), evidence.getIdentityFraudScore());
+        assertEquals(fraudResultItem.getContraIndicators(), evidence.getCi());
+        assertEquals(fraudResultItem.getDecisionScore(), evidence.getDecisionScore());
+        assertEquals(fraudResultItem.getActivityHistoryScore(), evidence.getActivityHistoryScore());
     }
 
     @Test
@@ -53,11 +53,11 @@ class EvidenceHelperTest {
 
         Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem, false);
 
-        assertEquals(evidence.getType(), IDENTITY_CHECK.toString());
-        assertEquals(evidence.getTxn(), fraudResultItem.getTransactionId());
-        assertEquals(evidence.getIdentityFraudScore(), fraudResultItem.getIdentityFraudScore());
-        assertEquals(evidence.getCi(), fraudResultItem.getContraIndicators());
-        assertEquals(evidence.getDecisionScore(), fraudResultItem.getDecisionScore());
+        assertEquals(IDENTITY_CHECK.toString(), evidence.getType());
+        assertEquals(fraudResultItem.getTransactionId(), evidence.getTxn());
+        assertEquals(fraudResultItem.getIdentityFraudScore(), evidence.getIdentityFraudScore());
+        assertEquals(fraudResultItem.getContraIndicators(), evidence.getCi());
+        assertEquals(fraudResultItem.getDecisionScore(), evidence.getDecisionScore());
         assertNotEquals(
                 evidence.getActivityHistoryScore(), fraudResultItem.getActivityHistoryScore());
         assertNull(evidence.getActivityHistoryScore());
@@ -86,17 +86,17 @@ class EvidenceHelperTest {
 
         Check mortalityCheck = new Check(MORTALITY_CHECK.toString().toLowerCase());
 
-        assertEquals(evidence.getType(), IDENTITY_CHECK.toString());
-        assertEquals(evidence.getTxn(), fraudResultItem.getTransactionId());
-        assertEquals(evidence.getIdentityFraudScore(), fraudResultItem.getIdentityFraudScore());
-        assertEquals(evidence.getCi(), fraudResultItem.getContraIndicators());
-        assertEquals(evidence.getDecisionScore(), fraudResultItem.getDecisionScore());
-        assertEquals(evidence.getActivityHistoryScore(), fraudResultItem.getActivityHistoryScore());
+        assertEquals(IDENTITY_CHECK.toString(), evidence.getType());
+        assertEquals(fraudResultItem.getTransactionId(), evidence.getTxn());
+        assertEquals(fraudResultItem.getIdentityFraudScore(), evidence.getIdentityFraudScore());
+        assertEquals(fraudResultItem.getContraIndicators(), evidence.getCi());
+        assertEquals(fraudResultItem.getDecisionScore(), evidence.getDecisionScore());
+        assertEquals(fraudResultItem.getActivityHistoryScore(), evidence.getActivityHistoryScore());
 
         if (checkType.equals("failedCheck")) {
-            assertEquals(evidence.getFailedCheckDetails().get(0), mortalityCheck);
+            assertEquals(mortalityCheck, evidence.getFailedCheckDetails().get(0));
         } else {
-            assertEquals(evidence.getCheckDetails().get(0), mortalityCheck);
+            assertEquals(mortalityCheck, evidence.getCheckDetails().get(0));
         }
     }
 
@@ -127,12 +127,12 @@ class EvidenceHelperTest {
         activityHistoryCheck.setIdentityCheckPolicy("none");
         activityHistoryCheck.setActivityFrom("1992-12-11");
 
-        assertEquals(evidence.getType(), IDENTITY_CHECK.toString());
-        assertEquals(evidence.getTxn(), fraudResultItem.getTransactionId());
-        assertEquals(evidence.getIdentityFraudScore(), fraudResultItem.getIdentityFraudScore());
-        assertEquals(evidence.getCi(), fraudResultItem.getContraIndicators());
-        assertEquals(evidence.getDecisionScore(), fraudResultItem.getDecisionScore());
-        assertEquals(evidence.getActivityHistoryScore(), fraudResultItem.getActivityHistoryScore());
+        assertEquals(IDENTITY_CHECK.toString(), evidence.getType());
+        assertEquals(fraudResultItem.getTransactionId(), evidence.getTxn());
+        assertEquals(fraudResultItem.getIdentityFraudScore(), evidence.getIdentityFraudScore());
+        assertEquals(fraudResultItem.getContraIndicators(), evidence.getCi());
+        assertEquals(fraudResultItem.getDecisionScore(), evidence.getDecisionScore());
+        assertEquals(fraudResultItem.getActivityHistoryScore(), evidence.getActivityHistoryScore());
 
         List<Check> checkDetails = evidence.getCheckDetails();
         if (checkType.equals("failedCheck")) {
@@ -140,7 +140,7 @@ class EvidenceHelperTest {
         }
         for (Check check : checkDetails) {
             if (null == check.getFraudCheck()) {
-                assertEquals(check, activityHistoryCheck);
+                assertEquals(activityHistoryCheck, check);
             }
         }
     }
@@ -173,16 +173,16 @@ class EvidenceHelperTest {
         Check impersonationRiskCheck = new Check(IMPERSONATION_RISK_CHECK.toString().toLowerCase());
         impersonationRiskCheck.setTxn("02");
 
-        assertEquals(evidence.getType(), IDENTITY_CHECK.toString());
-        assertEquals(evidence.getTxn(), fraudResultItem.getTransactionId());
-        assertEquals(evidence.getIdentityFraudScore(), fraudResultItem.getIdentityFraudScore());
-        assertEquals(evidence.getCi(), fraudResultItem.getContraIndicators());
-        assertEquals(evidence.getDecisionScore(), fraudResultItem.getDecisionScore());
+        assertEquals(IDENTITY_CHECK.toString(), evidence.getType());
+        assertEquals(fraudResultItem.getTransactionId(), evidence.getTxn());
+        assertEquals(fraudResultItem.getIdentityFraudScore(), evidence.getIdentityFraudScore());
+        assertEquals(fraudResultItem.getContraIndicators(), evidence.getCi());
+        assertEquals(fraudResultItem.getDecisionScore(), evidence.getDecisionScore());
 
         if (checkType.equals("failedCheck")) {
-            assertEquals(evidence.getFailedCheckDetails().get(0), impersonationRiskCheck);
+            assertEquals(impersonationRiskCheck, evidence.getFailedCheckDetails().get(0));
         } else {
-            assertEquals(evidence.getCheckDetails().get(0), impersonationRiskCheck);
+            assertEquals(impersonationRiskCheck, evidence.getCheckDetails().get(0));
         }
     }
 
@@ -223,27 +223,27 @@ class EvidenceHelperTest {
         activityHistoryCheck.setIdentityCheckPolicy("none");
         activityHistoryCheck.setActivityFrom("1992-12-11");
 
-        assertEquals(evidence.getType(), IDENTITY_CHECK.toString());
-        assertEquals(evidence.getTxn(), fraudResultItem.getTransactionId());
-        assertEquals(evidence.getIdentityFraudScore(), fraudResultItem.getIdentityFraudScore());
-        assertEquals(evidence.getCi(), fraudResultItem.getContraIndicators());
-        assertEquals(evidence.getDecisionScore(), fraudResultItem.getDecisionScore());
-        assertEquals(evidence.getActivityHistoryScore(), fraudResultItem.getActivityHistoryScore());
+        assertEquals(IDENTITY_CHECK.toString(), evidence.getType());
+        assertEquals(fraudResultItem.getTransactionId(), evidence.getTxn());
+        assertEquals(fraudResultItem.getIdentityFraudScore(), evidence.getIdentityFraudScore());
+        assertEquals(fraudResultItem.getContraIndicators(), evidence.getCi());
+        assertEquals(fraudResultItem.getDecisionScore(), evidence.getDecisionScore());
+        assertEquals(fraudResultItem.getActivityHistoryScore(), evidence.getActivityHistoryScore());
 
         List<Check> checkDetails = evidence.getCheckDetails();
         if (checkType.equals("failedCheck")) {
-            assertEquals(evidence.getFailedCheckDetails().size(), 3);
+            assertEquals(3, evidence.getFailedCheckDetails().size());
             checkDetails = evidence.getFailedCheckDetails();
         }
         for (Check check : checkDetails) {
             if (null == check.getFraudCheck()) {
-                assertEquals(check, activityHistoryCheck);
+                assertEquals(activityHistoryCheck, check);
             } else {
                 if (check.getFraudCheck().equalsIgnoreCase(IMPERSONATION_RISK_CHECK.toString())) {
-                    assertEquals(check, impersonationRiskCheck);
+                    assertEquals(impersonationRiskCheck, check);
                 } else {
-                    assertEquals(check.getFraudCheck(), MORTALITY_CHECK.toString().toLowerCase());
-                    assertEquals(check.getCheckMethod(), "data");
+                    assertEquals(MORTALITY_CHECK.toString().toLowerCase(), check.getFraudCheck());
+                    assertEquals("data", check.getCheckMethod());
                     assertNull(check.getTxn());
                     assertNull(check.getIdentityCheckPolicy());
                 }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/EvidenceHelperTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/EvidenceHelperTest.java
@@ -1,0 +1,227 @@
+package uk.gov.di.ipv.cri.fraud.api.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.di.ipv.cri.fraud.api.domain.Evidence;
+import uk.gov.di.ipv.cri.fraud.api.domain.checkdetails.Check;
+import uk.gov.di.ipv.cri.fraud.library.persistence.item.FraudResultItem;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static uk.gov.di.ipv.cri.fraud.api.domain.EvidenceType.IDENTITY_CHECK;
+import static uk.gov.di.ipv.cri.fraud.library.domain.CheckType.IMPERSONATION_RISK_CHECK;
+import static uk.gov.di.ipv.cri.fraud.library.domain.CheckType.MORTALITY_CHECK;
+
+class EvidenceHelperTest {
+
+    @Test
+    void TestFraudResultItemISuccessfullyMappedToEvidence() {
+
+        FraudResultItem fraudResultItem = new FraudResultItem();
+
+        fraudResultItem.setIdentityFraudScore(1);
+        fraudResultItem.setContraIndicators(List.of("u101"));
+        fraudResultItem.setSessionId(UUID.randomUUID());
+        fraudResultItem.setTransactionId("01");
+
+        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem);
+
+        assertEquals(evidence.getType(), IDENTITY_CHECK.toString());
+        assertEquals(evidence.getTxn(), fraudResultItem.getTransactionId());
+        assertEquals(evidence.getIdentityFraudScore(), fraudResultItem.getIdentityFraudScore());
+        assertEquals(evidence.getCi(), fraudResultItem.getContraIndicators());
+        assertEquals(evidence.getDecisionScore(), fraudResultItem.getDecisionScore());
+        assertEquals(evidence.getActivityHistoryScore(), fraudResultItem.getActivityHistoryScore());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"check", "failedCheck"})
+    void TestFraudResultItemISuccessfullyMappedToEvidenceWithChecks(String checkType) {
+
+        FraudResultItem fraudResultItem = new FraudResultItem();
+
+        fraudResultItem.setIdentityFraudScore(1);
+        fraudResultItem.setContraIndicators(List.of("u101"));
+        fraudResultItem.setSessionId(UUID.randomUUID());
+        fraudResultItem.setTransactionId("01");
+
+        if (checkType.equals("failedCheck")) {
+            fraudResultItem.setFailedCheckDetails(
+                    List.of(MORTALITY_CHECK.toString().toLowerCase()));
+        } else {
+            fraudResultItem.setCheckDetails(List.of(MORTALITY_CHECK.toString().toLowerCase()));
+        }
+
+        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem);
+
+        Check mortalityCheck = new Check(MORTALITY_CHECK.toString().toLowerCase());
+
+        assertEquals(evidence.getType(), IDENTITY_CHECK.toString());
+        assertEquals(evidence.getTxn(), fraudResultItem.getTransactionId());
+        assertEquals(evidence.getIdentityFraudScore(), fraudResultItem.getIdentityFraudScore());
+        assertEquals(evidence.getCi(), fraudResultItem.getContraIndicators());
+        assertEquals(evidence.getDecisionScore(), fraudResultItem.getDecisionScore());
+        assertEquals(evidence.getActivityHistoryScore(), fraudResultItem.getActivityHistoryScore());
+
+        if (checkType.equals("failedCheck")) {
+            assertEquals(evidence.getFailedCheckDetails().get(0), mortalityCheck);
+        } else {
+            assertEquals(evidence.getCheckDetails().get(0), mortalityCheck);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"check", "failedCheck"})
+    void TestFraudResultItemISuccessfullyMappedToEvidenceWithChecksWithActivityHistoryScore(
+            String checkType) {
+
+        FraudResultItem fraudResultItem = new FraudResultItem();
+
+        fraudResultItem.setIdentityFraudScore(1);
+        fraudResultItem.setContraIndicators(List.of("u101"));
+        fraudResultItem.setSessionId(UUID.randomUUID());
+        fraudResultItem.setTransactionId("01");
+        fraudResultItem.setActivityHistoryScore(1);
+        fraudResultItem.setActivityFrom("1992-12-11");
+
+        if (checkType.equals("failedCheck")) {
+            fraudResultItem.setFailedCheckDetails(
+                    List.of(MORTALITY_CHECK.toString().toLowerCase()));
+        } else {
+            fraudResultItem.setCheckDetails(List.of(MORTALITY_CHECK.toString().toLowerCase()));
+        }
+
+        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem);
+
+        Check activityHistoryCheck = new Check();
+        activityHistoryCheck.setIdentityCheckPolicy("none");
+        activityHistoryCheck.setActivityFrom("1992-12-11");
+
+        assertEquals(evidence.getType(), IDENTITY_CHECK.toString());
+        assertEquals(evidence.getTxn(), fraudResultItem.getTransactionId());
+        assertEquals(evidence.getIdentityFraudScore(), fraudResultItem.getIdentityFraudScore());
+        assertEquals(evidence.getCi(), fraudResultItem.getContraIndicators());
+        assertEquals(evidence.getDecisionScore(), fraudResultItem.getDecisionScore());
+        assertEquals(evidence.getActivityHistoryScore(), fraudResultItem.getActivityHistoryScore());
+
+        List<Check> checkDetails = evidence.getCheckDetails();
+        if (checkType.equals("failedCheck")) {
+            checkDetails = evidence.getFailedCheckDetails();
+        }
+        for (Check check : checkDetails) {
+            if (null == check.getFraudCheck()) {
+                assertEquals(check, activityHistoryCheck);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"check", "failedCheck"})
+    void TestFraudResultItemISuccessfullyMappedToEvidenceWithChecksWithImpersonationCheck(
+            String checkType) {
+
+        FraudResultItem fraudResultItem = new FraudResultItem();
+
+        fraudResultItem.setIdentityFraudScore(1);
+        fraudResultItem.setContraIndicators(List.of("u101"));
+        fraudResultItem.setSessionId(UUID.randomUUID());
+        fraudResultItem.setTransactionId("01");
+        fraudResultItem.setPepTransactionId("02");
+        fraudResultItem.setActivityHistoryScore(1);
+        fraudResultItem.setActivityFrom("1992-12-11");
+
+        if (checkType.equals("failedCheck")) {
+            fraudResultItem.setFailedCheckDetails(
+                    List.of(IMPERSONATION_RISK_CHECK.toString().toLowerCase()));
+        } else {
+            fraudResultItem.setCheckDetails(
+                    List.of(IMPERSONATION_RISK_CHECK.toString().toLowerCase()));
+        }
+
+        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem);
+
+        Check impersonationRiskCheck = new Check(IMPERSONATION_RISK_CHECK.toString().toLowerCase());
+        impersonationRiskCheck.setTxn("02");
+
+        assertEquals(evidence.getType(), IDENTITY_CHECK.toString());
+        assertEquals(evidence.getTxn(), fraudResultItem.getTransactionId());
+        assertEquals(evidence.getIdentityFraudScore(), fraudResultItem.getIdentityFraudScore());
+        assertEquals(evidence.getCi(), fraudResultItem.getContraIndicators());
+        assertEquals(evidence.getDecisionScore(), fraudResultItem.getDecisionScore());
+
+        if (checkType.equals("failedCheck")) {
+            assertEquals(evidence.getFailedCheckDetails().get(0), impersonationRiskCheck);
+        } else {
+            assertEquals(evidence.getCheckDetails().get(0), impersonationRiskCheck);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"check", "failedCheck"})
+    void
+            TestFraudResultItemISuccessfullyMappedToEvidenceWithChecksWithImpersonationCheckAndActivityHistoryScore(
+                    String checkType) {
+
+        FraudResultItem fraudResultItem = new FraudResultItem();
+
+        fraudResultItem.setIdentityFraudScore(1);
+        fraudResultItem.setContraIndicators(List.of("u101"));
+        fraudResultItem.setSessionId(UUID.randomUUID());
+        fraudResultItem.setTransactionId("01");
+        fraudResultItem.setPepTransactionId("02");
+        fraudResultItem.setActivityHistoryScore(1);
+        fraudResultItem.setActivityFrom("1992-12-11");
+
+        if (checkType.equals("failedCheck")) {
+            fraudResultItem.setFailedCheckDetails(
+                    List.of(
+                            IMPERSONATION_RISK_CHECK.toString().toLowerCase(),
+                            MORTALITY_CHECK.toString().toLowerCase()));
+        } else {
+            fraudResultItem.setCheckDetails(
+                    List.of(
+                            IMPERSONATION_RISK_CHECK.toString().toLowerCase(),
+                            MORTALITY_CHECK.toString().toLowerCase()));
+        }
+
+        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem);
+
+        Check impersonationRiskCheck = new Check(IMPERSONATION_RISK_CHECK.toString().toLowerCase());
+        impersonationRiskCheck.setTxn("02");
+
+        Check activityHistoryCheck = new Check();
+        activityHistoryCheck.setIdentityCheckPolicy("none");
+        activityHistoryCheck.setActivityFrom("1992-12-11");
+
+        assertEquals(evidence.getType(), IDENTITY_CHECK.toString());
+        assertEquals(evidence.getTxn(), fraudResultItem.getTransactionId());
+        assertEquals(evidence.getIdentityFraudScore(), fraudResultItem.getIdentityFraudScore());
+        assertEquals(evidence.getCi(), fraudResultItem.getContraIndicators());
+        assertEquals(evidence.getDecisionScore(), fraudResultItem.getDecisionScore());
+        assertEquals(evidence.getActivityHistoryScore(), fraudResultItem.getActivityHistoryScore());
+
+        List<Check> checkDetails = evidence.getCheckDetails();
+        if (checkType.equals("failedCheck")) {
+            assertEquals(evidence.getFailedCheckDetails().size(), 3);
+            checkDetails = evidence.getFailedCheckDetails();
+        }
+        for (Check check : checkDetails) {
+            if (null == check.getFraudCheck()) {
+                assertEquals(check, activityHistoryCheck);
+            } else {
+                if (check.getFraudCheck().equalsIgnoreCase(IMPERSONATION_RISK_CHECK.toString())) {
+                    assertEquals(check, impersonationRiskCheck);
+                } else {
+                    assertEquals(check.getFraudCheck(), MORTALITY_CHECK.toString().toLowerCase());
+                    assertEquals(check.getCheckMethod(), "data");
+                    assertNull(check.getTxn());
+                    assertNull(check.getIdentityCheckPolicy());
+                }
+            }
+        }
+    }
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/EvidenceHelperTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/EvidenceHelperTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static uk.gov.di.ipv.cri.fraud.api.domain.EvidenceType.IDENTITY_CHECK;
 import static uk.gov.di.ipv.cri.fraud.library.domain.CheckType.IMPERSONATION_RISK_CHECK;
@@ -28,7 +29,7 @@ class EvidenceHelperTest {
         fraudResultItem.setSessionId(UUID.randomUUID());
         fraudResultItem.setTransactionId("01");
 
-        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem);
+        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem, true);
 
         assertEquals(evidence.getType(), IDENTITY_CHECK.toString());
         assertEquals(evidence.getTxn(), fraudResultItem.getTransactionId());
@@ -36,6 +37,31 @@ class EvidenceHelperTest {
         assertEquals(evidence.getCi(), fraudResultItem.getContraIndicators());
         assertEquals(evidence.getDecisionScore(), fraudResultItem.getDecisionScore());
         assertEquals(evidence.getActivityHistoryScore(), fraudResultItem.getActivityHistoryScore());
+    }
+
+    @Test
+    void TestFraudResultItemISuccessfullyMappedToEvidenceWithoutActivityHistoryIfToggleSet() {
+
+        FraudResultItem fraudResultItem = new FraudResultItem();
+
+        fraudResultItem.setIdentityFraudScore(1);
+        fraudResultItem.setContraIndicators(List.of("u101"));
+        fraudResultItem.setSessionId(UUID.randomUUID());
+        fraudResultItem.setTransactionId("01");
+        fraudResultItem.setActivityHistoryScore(1);
+        fraudResultItem.setActivityFrom("1992-12-11");
+
+        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem, false);
+
+        assertEquals(evidence.getType(), IDENTITY_CHECK.toString());
+        assertEquals(evidence.getTxn(), fraudResultItem.getTransactionId());
+        assertEquals(evidence.getIdentityFraudScore(), fraudResultItem.getIdentityFraudScore());
+        assertEquals(evidence.getCi(), fraudResultItem.getContraIndicators());
+        assertEquals(evidence.getDecisionScore(), fraudResultItem.getDecisionScore());
+        assertNotEquals(
+                evidence.getActivityHistoryScore(), fraudResultItem.getActivityHistoryScore());
+        assertNull(evidence.getActivityHistoryScore());
+        assertNull(evidence.getCheckDetails());
     }
 
     @ParameterizedTest
@@ -56,7 +82,7 @@ class EvidenceHelperTest {
             fraudResultItem.setCheckDetails(List.of(MORTALITY_CHECK.toString().toLowerCase()));
         }
 
-        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem);
+        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem, true);
 
         Check mortalityCheck = new Check(MORTALITY_CHECK.toString().toLowerCase());
 
@@ -95,7 +121,7 @@ class EvidenceHelperTest {
             fraudResultItem.setCheckDetails(List.of(MORTALITY_CHECK.toString().toLowerCase()));
         }
 
-        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem);
+        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem, true);
 
         Check activityHistoryCheck = new Check();
         activityHistoryCheck.setIdentityCheckPolicy("none");
@@ -142,7 +168,7 @@ class EvidenceHelperTest {
                     List.of(IMPERSONATION_RISK_CHECK.toString().toLowerCase()));
         }
 
-        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem);
+        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem, true);
 
         Check impersonationRiskCheck = new Check(IMPERSONATION_RISK_CHECK.toString().toLowerCase());
         impersonationRiskCheck.setTxn("02");
@@ -188,7 +214,7 @@ class EvidenceHelperTest {
                             MORTALITY_CHECK.toString().toLowerCase()));
         }
 
-        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem);
+        Evidence evidence = EvidenceHelper.fraudCheckResultItemToEvidence(fraudResultItem, true);
 
         Check impersonationRiskCheck = new Check(IMPERSONATION_RISK_CHECK.toString().toLowerCase());
         impersonationRiskCheck.setTxn("02");

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/IssueCredentialAuditGeneratorTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/IssueCredentialAuditGeneratorTest.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class IssueCredentialAuditGeneratorTest {
+
     @Test
     void auditTest1() throws JsonProcessingException {
 
@@ -44,7 +45,6 @@ class IssueCredentialAuditGeneratorTest {
                         .withDefaultPrettyPrinter();
         String json = ow.writeValueAsString(ev1);
 
-        System.out.println(json);
         assertNotNull(json);
     }
 }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/IssueCredentialAuditGeneratorTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/IssueCredentialAuditGeneratorTest.java
@@ -29,7 +29,7 @@ class IssueCredentialAuditGeneratorTest {
 
         VCISSFraudAuditExtension ext =
                 IssueCredentialFraudAuditExtensionUtil.generateVCISSFraudAuditExtension(
-                        "TestIssuer", List.of(fraudResultItem1));
+                        "TestIssuer", List.of(fraudResultItem1), true);
 
         AuditEventType evt1 = AuditEventType.VC_ISSUED;
         AuditEvent<VCISSFraudAuditExtension> ev1 =

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/persistence/item/FraudResultItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/persistence/item/FraudResultItem.java
@@ -4,6 +4,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @DynamoDbBean
@@ -12,6 +13,7 @@ public class FraudResultItem {
     private List<String> contraIndicators;
     private Integer identityFraudScore;
     private Integer activityHistoryScore;
+    private String activityFrom;
     private String transactionId;
     private String pepTransactionId;
     private String decisionScore;
@@ -105,5 +107,45 @@ public class FraudResultItem {
 
     public void setActivityHistoryScore(Integer activityHistoryScore) {
         this.activityHistoryScore = activityHistoryScore;
+    }
+
+    public String getActivityFrom() {
+        return activityFrom;
+    }
+
+    public void setActivityFrom(String activityFrom) {
+        this.activityFrom = activityFrom;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        FraudResultItem that = (FraudResultItem) o;
+        return Objects.equals(sessionId, that.sessionId)
+                && Objects.equals(contraIndicators, that.contraIndicators)
+                && Objects.equals(identityFraudScore, that.identityFraudScore)
+                && Objects.equals(activityHistoryScore, that.activityHistoryScore)
+                && Objects.equals(activityFrom, that.activityFrom)
+                && Objects.equals(transactionId, that.transactionId)
+                && Objects.equals(pepTransactionId, that.pepTransactionId)
+                && Objects.equals(decisionScore, that.decisionScore)
+                && Objects.equals(checkDetails, that.checkDetails)
+                && Objects.equals(failedCheckDetails, that.failedCheckDetails);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                sessionId,
+                contraIndicators,
+                identityFraudScore,
+                activityHistoryScore,
+                activityFrom,
+                transactionId,
+                pepTransactionId,
+                decisionScore,
+                checkDetails,
+                failedCheckDetails);
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Added activity history score to the VC
Added empty check to the VC for activity from
```
				{
					"checkMethod": "data",
					"activityFrom": "2019-01-01",
					"identityCheckPolicy": "none"
				}
```
Updated tests
Added new acceptance tests

### Why did it change

So that we could return activity history score while still adhering to RFC 24

