### PR TITLE
Lime 670 no exp date field in vc fraud cri

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
@@ -512,13 +512,8 @@ public class FraudPageObject extends UniversalSteps {
         return jsonNode.get(vc);
     }
 
-    public void expiryAbsentFromVC(String checkType) throws JsonProcessingException {
-        JsonNode vcNode = getVCFromJson("vc");
-        JsonNode evidenceNode = vcNode.get("evidence").get(0);
-        boolean expInVC =
-                evidenceNode.findValues("expiryDate").stream()
-                        .anyMatch(x -> x.asText().equals(checkType));
-        assertFalse(expInVC);
+    public void expiryAbsentFromVC(String exp) throws JsonProcessingException {
+        assertNbfIsRecentAndExpiryIsNull();
     }
 
     public void assertCurrentPageIsFraudCheckPage() {

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class FraudPageObject extends UniversalSteps {
 
@@ -511,8 +512,15 @@ public class FraudPageObject extends UniversalSteps {
         return jsonNode.get(vc);
     }
 
-    public void expiryAbsentFromVC() throws JsonProcessingException {
-        assertNbfIsRecentAndExpiryIsNull();
+    public void expiryAbsentFromVC(String checkType) throws JsonProcessingException {
+        //assertNbfIsRecentAndExpiryIsNull();
+        JsonNode vcNode = getVCFromJson("vc");
+        JsonNode evidenceNode = vcNode.get("evidence").get(0);
+        boolean expInVC =
+                evidenceNode.findValues("expiryDate").stream()
+                        .anyMatch(x -> x.asText().equals(checkType));
+        assertFalse(expInVC);
+
     }
 
     public void assertCurrentPageIsFraudCheckPage() {
@@ -533,7 +541,7 @@ public class FraudPageObject extends UniversalSteps {
                 LocalDateTime.ofEpochSecond(Long.parseLong(nbf), 0, ZoneOffset.UTC);
 
         assertNull(expNode);
-        assertTrue(isWithinRange(nbfDateTime));
+        assertFalse(isWithinRange(nbfDateTime));
     }
 
     boolean isWithinRange(LocalDateTime testDate) {

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
@@ -27,7 +27,6 @@ import static gov.di_ipv_fraud.utilities.BrowserUtils.checkOkHttpResponseOnLink;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FraudPageObject extends UniversalSteps {

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
@@ -534,12 +534,12 @@ public class FraudPageObject extends UniversalSteps {
                 LocalDateTime.ofEpochSecond(Long.parseLong(nbf), 0, ZoneOffset.UTC);
 
         assertNull(expNode);
-        assertFalse(isWithinRange(nbfDateTime));
+        assertTrue(isWithinRange(nbfDateTime));
     }
 
     boolean isWithinRange(LocalDateTime testDate) {
-        LocalDateTime nbfMin = LocalDateTime.now().minusSeconds(30);
-        LocalDateTime nbfMax = LocalDateTime.now().plusSeconds(30);
+        LocalDateTime nbfMin = LocalDateTime.now(ZoneOffset.UTC).minusSeconds(30);
+        LocalDateTime nbfMax = LocalDateTime.now(ZoneOffset.UTC).plusSeconds(30);
         LOGGER.info("nbfMin " + nbfMin);
         LOGGER.info("nbfMax " + nbfMax);
         LOGGER.info("nbf " + testDate);

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
@@ -27,8 +27,8 @@ import static gov.di_ipv_fraud.utilities.BrowserUtils.checkOkHttpResponseOnLink;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FraudPageObject extends UniversalSteps {
 
@@ -513,14 +513,12 @@ public class FraudPageObject extends UniversalSteps {
     }
 
     public void expiryAbsentFromVC(String checkType) throws JsonProcessingException {
-        //assertNbfIsRecentAndExpiryIsNull();
         JsonNode vcNode = getVCFromJson("vc");
         JsonNode evidenceNode = vcNode.get("evidence").get(0);
         boolean expInVC =
                 evidenceNode.findValues("expiryDate").stream()
                         .anyMatch(x -> x.asText().equals(checkType));
         assertFalse(expInVC);
-
     }
 
     public void assertCurrentPageIsFraudCheckPage() {

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
@@ -220,8 +220,8 @@ public class FraudStepDefs extends FraudPageObject {
         checkFailedInVC(checkDetails);
     }
 
-    @And("^Expiry time should be absent in the JSON payload$")
-    public void nbfAndExpiryInJsonResponse() throws JsonProcessingException {
-        expiryAbsentFromVC();
+    @And("^(.*) should not be absent in the JSON payload$")
+    public void nbfAndExpiryInJsonResponse(String checkType) throws JsonProcessingException {
+        expiryAbsentFromVC(checkType);
     }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
@@ -221,7 +221,7 @@ public class FraudStepDefs extends FraudPageObject {
     }
 
     @And("^(.*) should not be present in the JSON payload$")
-    public void nbfAndExpiryInJsonResponse(String checkType) throws JsonProcessingException {
-        expiryAbsentFromVC(checkType);
+    public void nbfAndExpiryInJsonResponse(String exp) throws JsonProcessingException {
+        expiryAbsentFromVC(exp);
     }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
@@ -220,7 +220,7 @@ public class FraudStepDefs extends FraudPageObject {
         checkFailedInVC(checkDetails);
     }
 
-    @And("^(.*) should not be absent in the JSON payload$")
+    @And("^(.*) should not be present in the JSON payload$")
     public void nbfAndExpiryInJsonResponse(String checkType) throws JsonProcessingException {
         expiryAbsentFromVC(checkType);
     }

--- a/acceptance-tests/src/test/resources/features/FraudCRI.feature
+++ b/acceptance-tests/src/test/resources/features/FraudCRI.feature
@@ -7,7 +7,7 @@ Feature: Fraud CRI
     And I click the Fraud CRI for the testEnvironment
     Then I search for user number 12 in the ThirdParty table
     And I navigate to the verifiable issuer to check for a Valid response from thirdParty
-    And ExpiryDate should not be absent in the JSON payload
+    And ExpiryDate should not be present in the JSON payload
     And The test is complete and I close the driver
 
   @happy_path @build-fraud @staging-fraud @integration-fraud

--- a/acceptance-tests/src/test/resources/features/FraudCRI.feature
+++ b/acceptance-tests/src/test/resources/features/FraudCRI.feature
@@ -7,7 +7,7 @@ Feature: Fraud CRI
     And I click the Fraud CRI for the testEnvironment
     Then I search for user number 12 in the ThirdParty table
     And I navigate to the verifiable issuer to check for a Valid response from thirdParty
-    And Expiry time should be absent in the JSON payload
+    And ExpiryDate should not be absent in the JSON payload
     And The test is complete and I close the driver
 
   @happy_path @build-fraud @staging-fraud @integration-fraud

--- a/acceptance-tests/src/test/resources/features/FraudCRI.feature
+++ b/acceptance-tests/src/test/resources/features/FraudCRI.feature
@@ -7,7 +7,7 @@ Feature: Fraud CRI
     And I click the Fraud CRI for the testEnvironment
     Then I search for user number 12 in the ThirdParty table
     And I navigate to the verifiable issuer to check for a Valid response from thirdParty
-    And ExpiryDate should not be present in the JSON payload
+    And exp should not be present in the JSON payload
     And The test is complete and I close the driver
 
   @happy_path @build-fraud @staging-fraud @integration-fraud


### PR DESCRIPTION
Remove the existing test step where we validate the expiry date as 6 months from the current date
Add a new test step to validate that the exp date field is no longer available in the VCs in Fraud CRI

(https://govukverify.atlassian.net/browse/LIME-670)


