### PR TITLE
LIME-565: Toggling activity history on in integration and production

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -159,8 +159,8 @@ Mappings:
       dev: "true"
       build: "true"
       staging: "true"
-      integration: "false"
-      production: "false"
+      integration: "true"
+      production: "true"
 
 
 Resources:


### PR DESCRIPTION
## Proposed changes

### What changed

Enabled activity history score in integration and production

### Why did it change

to allow us to use AC in production for F2F

