### PR TITLE
LIME-698: Fixed issue where ttl was not set correctly for results

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -533,6 +533,9 @@ Resources:
       KeySchema:
         - AttributeName: "sessionId"
           KeyType: "HASH"
+      TimeToLiveSpecification:
+        AttributeName: "ttl"
+        Enabled: true
 
 ####################################################################
 #                                                                  #

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
@@ -156,6 +156,7 @@ public class FraudHandler
                             result.getIdentityCheckScore(),
                             result.getActivityHistoryScore(),
                             result.getDecisionScore());
+            fraudResultItem.setTtl(configurationService.getFraudResultItemExpirationEpoch());
             fraudResultItem.setTransactionId(result.getTransactionId());
             fraudResultItem.setPepTransactionId(result.getPepTransactionId());
 

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationServiceTest.java
@@ -51,6 +51,7 @@ class ConfigurationServiceTest {
         when(mockParamProvider.get("/null/contraindicationMappings")).thenReturn("null:null");
         when(mockParamProvider.get("/null/zeroScoreUcodes")).thenReturn("U001,U002");
         when(mockParamProvider.get("/null/noFileFoundThreshold")).thenReturn("35");
+        when(mockParamProvider.get("/null/SessionTtl")).thenReturn("7200");
         when(mockSecretsProvider.get(String.format(KEY_FORMAT, env, hmacKey)))
                 .thenReturn(testHmacKeyValue);
         when(mockSecretsProvider.get(

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
@@ -185,7 +185,12 @@ class IdentityVerificationServiceTest {
         assertEquals(mappedFraudCodes[0], result.getContraIndicators().get(0));
         assertEquals(mappedPEPCodes[0], result.getContraIndicators().get(1));
         assertEquals(1, result.getActivityHistoryScore());
-        assertEquals("1992-12-01", result.getActivityFrom());
+        assertEquals(
+                LocalDate.now()
+                        .minusMonths(366)
+                        .withDayOfMonth(1)
+                        .format(DateTimeFormatter.ISO_DATE),
+                result.getActivityFrom());
 
         verify(personIdentityValidator).validate(testPersonIdentity);
         verify(mockThirdPartyGateway).performFraudCheck(testPersonIdentity, false);
@@ -496,7 +501,12 @@ class IdentityVerificationServiceTest {
         assertNotNull(result);
         assertTrue(result.isSuccess());
         assertEquals(1, result.getActivityHistoryScore());
-        assertEquals("1992-12-01", result.getActivityFrom());
+        assertEquals(
+                LocalDate.now()
+                        .minusMonths(366)
+                        .withDayOfMonth(1)
+                        .format(DateTimeFormatter.ISO_DATE),
+                result.getActivityFrom());
 
         // Fraud ucodes
         assertEquals(mappedFraudCodes[0], result.getContraIndicators().get(0));

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/persistence/item/FraudResultItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/persistence/item/FraudResultItem.java
@@ -21,6 +21,8 @@ public class FraudResultItem {
     private List<String> checkDetails;
     private List<String> failedCheckDetails;
 
+    private long ttl;
+
     public FraudResultItem() {}
 
     public FraudResultItem(
@@ -115,6 +117,14 @@ public class FraudResultItem {
 
     public void setActivityFrom(String activityFrom) {
         this.activityFrom = activityFrom;
+    }
+
+    public long getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(long ttl) {
+        this.ttl = ttl;
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

### What changed

Updated the ttl for result items

### Why did it change

To ensure results expire with the session as expected

